### PR TITLE
feat: Add disk root size query tool.

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.py
@@ -25,7 +25,7 @@ class NodeDiskRootSizeTool(BuiltinTool):
         step = APOUtils.get_step(start_time=start_time, end_time=end_time)
         interval = APOUtils.vec_from_duration(step * 1000)
         query = f"""
-        node_filesystem_size_bytes{{instance_name="{node}"}}[{interval}]
+        node_filesystem_size_bytes{{instance_name="{node}", mountpoint="/"}}[{interval}]
         """
         resp = requests.get(
             dify_config.APO_VM_URL + "/prometheus/api/v1/query_range",
@@ -52,7 +52,7 @@ class NodeDiskRootSizeTool(BuiltinTool):
             timeseries.append(
                 {
                     "labels": labels,
-                    "legend": f"{labels.get('pid')}",
+                    "legend": f"{labels.get('instance_name')}",
                     "chart": {
                         "chartData": chart_data,
                     }

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.py
@@ -1,0 +1,70 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class NodeDiskRootSizeTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        node = tool_parameters.get('node', '.*')
+        start_time = tool_parameters.get("startTime")
+        end_time = tool_parameters.get("endTime")
+        step = APOUtils.get_step(start_time=start_time, end_time=end_time)
+        interval = APOUtils.vec_from_duration(step * 1000)
+        query = f"""
+        node_filesystem_size_bytes{{instance_name="{node}"}}[{interval}]
+        """
+        resp = requests.get(
+            dify_config.APO_VM_URL + "/prometheus/api/v1/query_range",
+            params={
+                'query': query,
+                'start': start_time / 1000,
+                'end': end_time / 1000,
+                'step': APOUtils.get_step_with_unit(start_time, end_time)
+            }
+        ).json()
+
+        timeseries = []
+        for res in resp.get('data', {}).get('result', []):
+            labels = res.get('metric')
+            chart_data = {}
+            for pair in res.get('values', []):
+                if len(pair) < 2:
+                    continue
+                try:
+                    value = float(pair[1])
+                    chart_data[pair[0] * 1_000_000] = value
+                except (ValueError, TypeError) as e:
+                    continue
+            timeseries.append(
+                {
+                    "labels": labels,
+                    "legend": f"{labels.get('pid')}",
+                    "chart": {
+                        "chartData": chart_data,
+                    }
+                }
+            )      
+            # timeseries数组 [{"labels": {}, "chart:{"chartData": {"time": value}"}}]
+        resp_json = json.dumps({
+            'type': 'metric',
+            'display': True,
+            'unit': 'byte',
+            'data': {
+                'timeseries': timeseries
+            }
+        })
+        yield self.create_text_message(resp_json)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.yaml
@@ -1,0 +1,53 @@
+identity:
+  name: 主机磁盘根分区大小
+  author: APO
+  label:
+    en_US: Node disk root size
+    zh_Hans: 主机磁盘根分区大小
+description:
+  human:
+    en_US: Node disk root size
+    zh_Hans: 主机磁盘根分区大小
+  llm: Node disk root size
+display:
+  type: metric
+  title: Node disk root size
+  unit: byte
+parameters:
+  - name: node
+    type: string
+    required: False
+    label:
+      en_US: node
+      zh_Hans: node
+    human_description:
+      en_US: node
+      zh_Hans: node
+    llm_description: node
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm


### PR DESCRIPTION
## Summary by Sourcery

Add a built-in tool to query node disk root partition sizes from Prometheus and return them as a time series metric

New Features:
- Implement NodeDiskRootSizeTool to fetch and format disk root size data over time
- Add YAML provider with metadata and parameters for the node disk root size tool