### PR TITLE
feat: Add node param when query thread polaris metrics.

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisEpollTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = ".*"
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Epoll',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_file_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_file_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisFileTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - File',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_file_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_file_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_futex_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_futex_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisFutexTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Futex',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_futex_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_futex_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_idle_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_idle_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisIdleTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Idle',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_idle_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_idle_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisNetTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Net',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisOncpuTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - OnCPU',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_other_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_other_time.py
@@ -20,12 +20,16 @@ class ThreadPolarisOtherTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Other',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_other_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_other_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.py
@@ -20,12 +20,17 @@ class ThreadPolarisRunqueueTimeTool(BuiltinTool):
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         pod = tool_parameters.get('pod', '.*')
+        node = tool_parameters.get('node', '.*')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
+
+        if not node:
+            node = '.*'
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Runqueue',
             'params': {
-                'pod': pod
+                'pod': pod,
+                'node_name': node
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.yaml
@@ -25,6 +25,17 @@ parameters:
       zh_Hans: Pod名称
     llm_description: Pod name
     form: llm
+  - name: node
+    type: string
+    required: False
+    label: 
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
   - name: startTime
     type: number
     required: true


### PR DESCRIPTION
## Summary by Sourcery

Introduce optional node filtering to all Thread Polaris metric tools by adding a 'node' parameter in their definitions and propagating it into the metric request as 'node_name' with a default wildcard value.

New Features:
- Add optional 'node' parameter to Thread Polaris metric tools for node-based filtering across all metric types (Epoll, File, Futex, Idle, Net, OnCPU, Runqueue, Other)

Enhancements:
- Include 'node_name' in the API request payload and default it to a wildcard when the node parameter is not provided