### PR TITLE
feat: Add process metric query tools.

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
@@ -23,9 +23,8 @@ class ProcessCPUUsageTool(BuiltinTool):
 
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        instance_name = tool_parameters.get('nodeName', '.*')
-        if not instance_name:
-            instance_name = ".*"
+        instance_name = tool_parameters.get('nodeName', '.*') or ".*"
+
 
         step = APOUtils.get_step(start_time=start_time, end_time=end_time)
         interval = APOUtils.vec_from_duration(step * 1000)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
@@ -1,0 +1,84 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class ProcessCPUUsageTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        group_name = tool_parameters.get('groupName', '.*')
+        if not group_name:
+            group_name = '.*'
+        start_time = tool_parameters.get("startTime")
+        end_time = tool_parameters.get("endTime")
+        instance_name = tool_parameters.get('nodeName', '.*')
+        if not instance_name:
+            instance_name = ".*"
+
+        step = APOUtils.get_step(start_time=start_time, end_time=end_time)
+        interval = APOUtils.vec_from_duration(step * 1000)
+
+        query = f"""
+        sum by (instance_name, groupname) (
+            increase(namedprocess_namegroup_cpu_seconds_total{{instance_name=~"{instance_name}", groupname=~"{group_name}"}}[{interval}])
+        ) / 
+        sum(
+            increase(namedprocess_namegroup_cpu_seconds_total{{instance_name=~"{instance_name}"}}[{interval}])
+        ) * 100
+        """
+        resp = requests.get(
+            dify_config.APO_VM_URL + "/prometheus/api/v1/query_range",
+            params={
+                'query': query,
+                'start': start_time / 1000,
+                'end': end_time / 1000,
+                'step': APOUtils.get_step_with_unit(start_time, end_time)
+            }
+        ).json()
+
+        timeseries = []
+        for res in resp.get('data', {}).get('result', []):
+            labels = res.get('metric')
+            chart_data = {}
+            for pair in res.get('values', []):
+                if len(pair) < 2:
+                    continue
+                try:
+                    value = float(pair[1])
+                    chart_data[pair[0] * 1_000_000] = value
+                except (ValueError, TypeError) as e:
+                    continue
+            timeseries.append(
+                {
+                    "labels": labels,
+                    "legend": f"{labels.get('groupname')}",
+                    "chart": {
+                        "chartData": chart_data,
+                    }
+                }
+            )      
+        if len(timeseries) == 0:
+            yield self.create_text_message("")
+        else:
+            resp_json = json.dumps({
+                'type': 'metric',
+                'display': True,
+                'unit': 'percentunit',
+                'data': {
+                    'timeseries': timeseries
+                }
+            })
+            yield self.create_text_message(resp_json)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
@@ -19,9 +19,8 @@ class ProcessCPUUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        group_name = tool_parameters.get('groupName', '.*')
-        if not group_name:
-            group_name = '.*'
+        group_name = tool_parameters.get('groupName', '.*') or '.*'
+
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         instance_name = tool_parameters.get('nodeName', '.*')

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: 查询进程CPU使用率
+  author: APO
+  label:
+    en_US: Query process CPU usage
+    zh_Hans: 查询进程CPU使用率
+description:
+  human:
+    en_US: Query process CPU usage
+    zh_Hans: 查询进程CPU使用率
+  llm: Query process CPU usage
+display:
+  type: metric
+  title: 查询进程CPU使用率
+  unit: "percentunit"
+parameters:
+  - name: groupName
+    type: string
+    required: False
+    label:
+      en_US: Process name(eg:name1|name2)
+      zh_Hans: 进程名（正则查询格式：name1|name2）
+    human_description:
+      en_US: Process name(eg:name1|name2)
+      zh_Hans: 进程名（正则查询格式：name1|name2）
+    llm_description: Process name(eg:name1|name2)
+    form: llm
+  - name: nodeName
+    type: string
+    required: true
+    label:
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
@@ -23,9 +23,8 @@ class ProcessMemoryUsageTool(BuiltinTool):
 
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        instance_name = tool_parameters.get('nodeName', '.*')
-        if not instance_name:
-            instance_name = ".*"
+        instance_name = tool_parameters.get('nodeName', '.*') or ".*"
+
 
         query = f"""
         namedprocess_namegroup_memory_bytes{{groupname=~"{group_name}", instance_name=~"{instance_name}"}} / 

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
@@ -19,9 +19,8 @@ class ProcessMemoryUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        group_name = tool_parameters.get('groupName', '.*')
-        if not group_name:
-            group_name = '.*'
+        group_name = tool_parameters.get('groupName', '.*') or '.*'
+
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         instance_name = tool_parameters.get('nodeName', '.*')

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
@@ -1,0 +1,77 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class ProcessMemoryUsageTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        group_name = tool_parameters.get('groupName', '.*')
+        if not group_name:
+            group_name = '.*'
+        start_time = tool_parameters.get("startTime")
+        end_time = tool_parameters.get("endTime")
+        instance_name = tool_parameters.get('nodeName', '.*')
+        if not instance_name:
+            instance_name = ".*"
+
+        query = f"""
+        namedprocess_namegroup_memory_bytes{{groupname=~"{group_name}", instance_name=~"{instance_name}"}} / 
+        sum(namedprocess_namegroup_memory_bytes{{instance_name=~"{instance_name}"}}) * 100
+        """
+        resp = requests.get(
+            dify_config.APO_VM_URL + "/prometheus/api/v1/query_range",
+            params={
+                'query': query,
+                'start': start_time / 1000,
+                'end': end_time / 1000,
+                'step': APOUtils.get_step_with_unit(start_time, end_time)
+            }
+        ).json()
+
+        timeseries = []
+        for res in resp.get('data', {}).get('result', []):
+            labels = res.get('metric')
+            chart_data = {}
+            for pair in res.get('values', []):
+                if len(pair) < 2:
+                    continue
+                try:
+                    value = float(pair[1])
+                    chart_data[pair[0] * 1_000_000] = value
+                except (ValueError, TypeError) as e:
+                    continue
+            timeseries.append(
+                {
+                    "labels": labels,
+                    "legend": f"{labels.get('groupname')}",
+                    "chart": {
+                        "chartData": chart_data,
+                    }
+                }
+            )      
+        if len(timeseries) == 0:
+            yield self.create_text_message("")
+        else:
+            resp_json = json.dumps({
+                'type': 'metric',
+                'display': True,
+                'unit': 'percentunit',
+                'data': {
+                    'timeseries': timeseries
+                }
+            })
+            yield self.create_text_message(resp_json)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: 查询进程内存使用率
+  author: APO
+  label:
+    en_US: Query process memory usage
+    zh_Hans: 查询进程内存使用率
+description:
+  human:
+    en_US: Query process memory usage
+    zh_Hans: 查询进程内存使用率
+  llm: Query process memory usage
+display:
+  type: metric
+  title: 查询进程内存使用率
+  unit: "percentunit"
+parameters:
+  - name: groupName
+    type: string
+    required: False
+    label:
+      en_US: Process name(eg:name1|name2)
+      zh_Hans: 进程名（正则查询格式：name1|name2）
+    human_description:
+      en_US: Process name(eg:name1|name2)
+      zh_Hans: 进程名（正则查询格式：name1|name2）
+    llm_description: Process name(eg:name1|name2)
+    form: llm
+  - name: nodeName
+    type: string
+    required: true
+    label:
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm


### PR DESCRIPTION
## Summary by Sourcery

Introduce two new built-in tools to query process resource usage metrics via Prometheus

New Features:
- Add ProcessCPUUsageTool to fetch and return process CPU usage percentage over time
- Add ProcessMemoryUsageTool to fetch and return process memory usage percentage over time
- Provide corresponding YAML configurations for both tools to define metadata and parameters