### PR TITLE
feat: Support vm rtt query.

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.py
@@ -18,15 +18,19 @@ class ContainerRTTTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get("pod")
-        namespace = tool_parameters.get("namespace")
+        pod = tool_parameters.get("pod") or ".*"
+        namespace = tool_parameters.get("namespace") or ".*"
+        node = tool_parameters.get("node") or ".*"
+        pid = tool_parameters.get("pid") or ".*"
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
           'metricName': '基础设施情况 - 容器网络 - 与下游服务RTT',
           'params': {
             "pod": pod,
-            "namespace": namespace
+            "namespace": namespace,
+            "node": node,
+            "pid": pid,
           },
           'startTime': start_time,
           'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.yaml
@@ -55,6 +55,32 @@ parameters:
       pt_BR: Data query start time(Microsecond)
     llm_description: Data query start time(Microsecond)
     form: llm
+  - name: pid
+    type: string
+    required: false
+    label:
+      en_US: pid
+      zh_Hans: pid
+      pt_BR: pid
+    human_description:
+      en_US: Specified pid
+      zh_Hans: 指定的PID
+      pt_BR: Specified pid
+    llm_description: Specified pid
+    form: llm
+  - name: node
+    type: string
+    required: false
+    label:
+      en_US: node
+      zh_Hans: node
+      pt_BR: node
+    human_description:
+      en_US: Specified node
+      zh_Hans: 指定的节点名称
+      pt_BR: Specified node
+    llm_description: Specified node
+    form: llm
   - name: endTime
     type: number
     required: true


### PR DESCRIPTION
## Summary by Sourcery

Enable VM RTT queries by extending the container RTT tool with optional node and PID filters and using wildcard defaults for unspecified parameters.

New Features:
- Add optional 'pid' and 'node' parameters to the container RTT query tool configuration and invocation

Enhancements:
- Default missing pod, namespace, node, and pid parameters to wildcard '.*' in the invoke function