### PR TITLE
fix(tool): Display log content.

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/query_full_logs.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/query_full_logs.py
@@ -41,9 +41,20 @@ class QueryFullLogsTool(BuiltinTool):
             json=params,
         )  
 
+        raw_logs = resp.json().get('logs', [])
+        contents = []
+        for raw_log in raw_logs:
+            content = raw_log.get('content','')
+            timestamp = raw_log.get('timestamp')
+            contents.append({'body': content, 'timestamp':timestamp})
+
         list = json.dumps({
             'type': 'log',
             'display': True,
-            'data': resp.json(),
+            'data': {
+                "logContents": {
+                    "contents": contents
+                }
+            },
         })
         yield self.create_text_message(list)


### PR DESCRIPTION
## Summary by Sourcery

Format and display log content by parsing the API response into structured entries with body and timestamp.

Bug Fixes:
- Extract 'logs' from the API response and build a structured list of entries containing content and timestamp.
- Replace raw JSON dump with a formatted 'logContents' object for better display.