### PR TITLE
fix: typo

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -20,7 +20,7 @@ FILES_URL=http://127.0.0.1:5001
 # APO Config
 APO_BACKEND_URL=http://127.0.0.1:8080
 APO_VM_URL=http://127.0.0.1:8428
-WORKFLOW_DIR=./inti_data/workflows
+WORKFLOW_DIR=./init_data/workflows
 INITIAL_LANGUAGE=en-US
 OFFLINE_MODE=false
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct a typo in the .env.example file.