### PR TITLE
fix: Logs are none type.

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/query_full_logs.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/query_full_logs.py
@@ -43,10 +43,12 @@ class QueryFullLogsTool(BuiltinTool):
 
         raw_logs = resp.json().get('logs', [])
         contents = []
-        for raw_log in raw_logs:
-            content = raw_log.get('content','')
-            timestamp = raw_log.get('timestamp')
-            contents.append({'body': content, 'timestamp':timestamp})
+        if raw_logs:
+            for raw_log in raw_logs:
+                content = raw_log.get('content','')
+                timestamp = raw_log.get('timestamp')
+                tags = raw_log.get('tags', {})
+                contents.append({'body': content, 'timestamp':timestamp, 'tags': tags})
 
         list = json.dumps({
             'type': 'log',


### PR DESCRIPTION
## Summary by Sourcery

Prevent errors when log responses lack data and enrich log entries with tags

Bug Fixes:
- Guard against raw_logs being None before iterating to avoid NoneType errors

Enhancements:
- Extract and include the `tags` field from each log entry in the output