### PR TITLE
feat: add level 1 tools

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.py
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.py
@@ -23,8 +23,8 @@ class AlertReportGen(BuiltinTool):
         tags = convert_to_json(tool_parameters.get("tags"), "tags", errormsgs)
         topology = convert_to_json(tool_parameters.get("topology"), "topology", errormsgs)
         rootCauseAnalysis = convert_to_json(tool_parameters.get("rootCauseAnalysis"), "rootCauseAnalysis", errormsgs)
-        suggest = convert_to_json(tool_parameters.get("suggest"), "suggest", errormsgs)
-        evidence = convert_to_json(tool_parameters.get("evidence"), "evidence", errormsgs)
+        suggest = convert_to_json(tool_parameters.get("suggest"), "suggest", errormsgs).get("suggest", {})
+        evidence = convert_to_json(tool_parameters.get("evidence"), "evidence", errormsgs).get("evidence", {})
         json_data = {
             'reportType': reportType,
             'overview': overview,

--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.py
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.py
@@ -34,7 +34,7 @@ class AlertReportGen(BuiltinTool):
             'suggest': suggest,
             'evidence': evidence
         }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/service/relation', json=json_data)
+        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/alerts/events/report/add', json=json_data)
         if resp.status_code != 200:
             errormsgs.append(f"Error while creating report, msg: {resp.text}")
         list = json.dumps({

--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.py
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.py
@@ -1,0 +1,54 @@
+import json
+import requests
+from collections.abc import Generator
+from typing import Any, Optional
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from configs import dify_config
+
+class AlertReportGen(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        reportType = tool_parameters.get("reportType")
+        errormsgs = []
+
+        overview = convert_to_json(tool_parameters.get("overview"), "overview", errormsgs)
+        tags = convert_to_json(tool_parameters.get("tags"), "tags", errormsgs)
+        topology = convert_to_json(tool_parameters.get("topology"), "topology", errormsgs)
+        rootCauseAnalysis = convert_to_json(tool_parameters.get("rootCauseAnalysis"), "rootCauseAnalysis", errormsgs)
+        suggest = convert_to_json(tool_parameters.get("suggest"), "suggest", errormsgs)
+        evidence = convert_to_json(tool_parameters.get("evidence"), "evidence", errormsgs)
+        json_data = {
+            'reportType': reportType,
+            'overview': overview,
+            'tags': tags,
+            'topology': topology,
+            'rootCauseAnalysis': rootCauseAnalysis,
+            'suggest': suggest,
+            'evidence': evidence
+        }
+        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/service/relation', json=json_data)
+        if resp.status_code != 200:
+            errormsgs.append(f"Error while creating report, msg: {resp.text}")
+        list = json.dumps({
+            'type': 'report',
+            'display': False,
+            'msg': errormsgs
+        })
+
+        yield self.create_text_message(list)
+
+
+def convert_to_json(data, name: str, errormsgs: list) -> dict:
+    try:
+        return json.loads(data)
+    except:
+        errormsgs.append(f'{name} Invalid JSON')
+        return {}  

--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.yaml
@@ -55,17 +55,17 @@ parameters:
       pt_BR: overview
     llm_description: overview
     form: llm
-  - name: toplogy
+  - name: topology
     type: string
     label:
-      en_US: toplogy
+      en_US: topology
       zh_Hans: 拓扑数据
-      pt_BR: toplogy
+      pt_BR: topology
     human_description:
-      en_US: toplogy
+      en_US: topology
       zh_Hans: 报告类型
-      pt_BR: toplogy
-    llm_description: toplogy data
+      pt_BR: topology
+    llm_description: topology data
     form: llm
   - name: rootCauseAnalysis
     type: string

--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_gen.yaml
@@ -1,0 +1,105 @@
+identity:
+  name: Generate alert analysis report
+  author: APO
+  label:
+    en_US: Generate alert analysis report
+    zh_Hans: 生成告警分析报告
+    pt_BR: Generate alert analysis report
+description:
+  human:
+    en_US: Generate alert analysis report
+    zh_Hans: 生成告警分析报告
+    pt_BR: Query the entry service topology
+  llm: Generate alert analysis report
+display:
+  type: report
+  title: report
+  unit: report
+parameters:
+  - name: reportType
+    type: string
+    required: true
+    label:
+      en_US: reportType
+      zh_Hans: 报告类型
+      pt_BR: reportType
+    human_description:
+      en_US: reportType
+      zh_Hans: 报告类型
+      pt_BR: reportType
+    llm_description: alert report type
+    form: llm
+  - name: tags
+    type: string
+    required: true
+    label:
+      en_US: tags
+      zh_Hans: 报告标签（用于检索）
+      pt_BR: tags
+    human_description:
+      en_US: reportType
+      zh_Hans: 报告标签（用于检索）
+      pt_BR: tags
+    llm_description: alert report tags
+    form: llm
+  - name: overview
+    type: string
+    required: true
+    label:
+      en_US: overview
+      zh_Hans: 告警事件总览
+      pt_BR: overview 
+    human_description:
+      en_US: overview
+      zh_Hans: 告警事件总览
+      pt_BR: overview
+    llm_description: overview
+    form: llm
+  - name: toplogy
+    type: string
+    label:
+      en_US: toplogy
+      zh_Hans: 拓扑数据
+      pt_BR: toplogy
+    human_description:
+      en_US: toplogy
+      zh_Hans: 报告类型
+      pt_BR: toplogy
+    llm_description: toplogy data
+    form: llm
+  - name: rootCauseAnalysis
+    type: string
+    label:
+      en_US: rootCauseAnalysis
+      zh_Hans: 根因分析结论
+      pt_BR: rootCauseAnalysis
+    human_description:
+      en_US: rootCauseAnalysis
+      zh_Hans: 根因分析结论
+      pt_BR: rootCauseAnalysis
+    llm_description: rootCauseAnalysis
+    form: llm
+  - name: suggest
+    type: string
+    label:
+      en_US: suggest
+      zh_Hans: 可行动方向建议
+      pt_BR: suggest
+    human_description:
+      en_US: suggest
+      zh_Hans: 可行动方向建议
+      pt_BR: suggest
+    llm_description: suggest
+    form: llm
+  - name: evidence
+    type: string
+    label:
+      en_US: evidence
+      zh_Hans: 验证数据
+      pt_BR: evidence
+    human_description:
+      en_US: evidence
+      zh_Hans: 根因分析结论
+      pt_BR: evidence
+    llm_description: evidence
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_url.py
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_url.py
@@ -1,0 +1,31 @@
+import json
+import requests
+from collections.abc import Generator
+from typing import Any, Optional
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from configs import dify_config
+
+class GetAlertReportURL(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        
+        alertEventId = tool_parameters.get('alertEventId')
+        reportText = tool_parameters.get('reportText')
+        frontPrefix = tool_parameters.get("frontPrefix", "")
+        start_time = tool_parameters.get("startTime")
+        end_time = tool_parameters.get("endTime")
+
+        if frontPrefix == "":
+            frontPrefix = dify_config.APO_BACKEND_URL
+        
+        end = int(end_time) + 1000000
+        res = f'{reportText}\n{frontPrefix}/#/report?alertEventId={alertEventId}&startTime={start_time}&endTime={end}'
+        yield self.create_text_message(res)

--- a/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_url.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_analysis/tools/alert_report_url.yaml
@@ -1,0 +1,76 @@
+identity:
+  name: get alert report url
+  author: APO
+  label:
+    en_US: Get alert report url
+    zh_Hans: 获取告警分析报告链接
+description:
+  human:
+    en_US: Get alert report url
+    zh_Hans: 获取告警分析报告链接
+  llm: Get alert report url
+display:
+  type: report_url
+  title: report_url
+  unit: report_url
+parameters:
+  - name: alertEventId
+    type: string
+    required: true
+    label:
+      en_US: alertEventId
+      zh_Hans: 告警事件ID
+      pt_BR: alertEventId
+    human_description:
+      en_US: alertEventId
+      zh_Hans: 报告类型
+      pt_BR: alertEventId
+    llm_description: alertEventId
+    form: llm
+  - name: reportText
+    type: string
+    required: true
+    label:
+      en_US: reportText
+      zh_Hans: 报告简要文本
+      pt_BR: reportText
+    human_description:
+      en_US: reportText
+      zh_Hans: 报告简要文本
+      pt_BR: reportText
+    llm_description: reportText
+    form: llm
+  - name: frontPrefix
+    type: string
+    label:
+      en_US: frontPrefix
+      zh_Hans: 报告访问地址
+      pt_BR: frontPrefix
+    human_description:
+      en_US: frontPrefix
+      zh_Hans: 报告访问地址
+      pt_BR: frontPrefix
+    llm_description: frontPrefix
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: Start Time
+      zh_Hans: 开始时间
+    human_description:
+      en_US: Start timestamp in microseconds
+      zh_Hans: 查询开始时间（微秒）
+    llm_description: Microsecond timestamp for start time
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: End Time
+      zh_Hans: 结束时间
+    human_description:
+      en_US: End timestamp in microseconds
+      zh_Hans: 查询结束时间（微秒）
+    llm_description: Microsecond timestamp for end time
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_instance_service_name.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_instance_service_name.py
@@ -1,0 +1,66 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional, Dict
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class InstanceServiceTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: Dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        pod = tool_parameters.get('pod')
+        container_id = tool_parameters.get('containerId')
+        pid = tool_parameters.get('pid')
+        node = tool_parameters.get('node')
+        start_time = tool_parameters.get('startTime')
+        end_time = tool_parameters.get('endTime')
+        cluster = tool_parameters.get('cluster', '')
+        try:
+            request_body = {
+                "cluster": cluster,
+                "endTime": end_time,
+                "startTime": start_time,
+                "tags": {
+                    "containerId": container_id or '',
+                    "nodeName": node or '',
+                    "pid": pid or '',
+                    "pod": pod or ''
+                }
+            }
+
+            response = requests.post(
+                f"{dify_config.APO_BACKEND_URL}/api/dataplane/servicename",
+                json=request_body,
+                timeout=10,
+            )
+            response.raise_for_status()
+
+            result = response.json().get("result", {})
+
+            formatted_data = json.dumps(
+                {
+                    "type": "list",
+                    "display": True,
+                    "data": result,
+                },
+                indent=2,
+            )
+            yield self.create_text_message(formatted_data)
+
+        except requests.RequestException as e:
+            yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
+        except json.JSONDecodeError:
+            yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
+        except Exception as e:
+            yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_instance_service_name.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_instance_service_name.yaml
@@ -1,0 +1,97 @@
+identity:
+  name: dataplane_instance_service
+  author: APO
+  label:
+    en_US: Query instance's service name
+    zh_Hans: 查询实例所属服务
+description:
+  human:
+    en_US: Query instance's service name
+    zh_Hans: 查询实例所属服务
+  llm: Query instance's service name
+display:
+  type: metric
+  title: Instance service
+  unit: number
+parameters:
+  - name: containerId
+    type: string
+    required: false
+    label:
+      en_US: containerId
+      zh_Hans: 容器id
+    human_description:
+      en_US: Container id
+      zh_Hans: 容器id
+    llm_description: Container id
+    form: llm
+  - name: nodeName
+    type: string
+    required: false
+    label:
+      en_US: Node name
+      zh_Hans: 主机名
+    human_description:
+      en_US: Node name
+      zh_Hans: 主机名
+    llm_description: Node name
+    form: llm
+  - name: pid
+    type: string
+    required: false
+    label:
+      en_US: pid
+      zh_Hans: pid
+    human_description:
+      en_US: pid
+      zh_Hans: pid
+    llm_description: pid
+    form: llm
+  - name: pod
+    type: string
+    required: false
+    label:
+      en_US: pod
+      zh_Hans: pod
+    human_description:
+      en_US: pod
+      zh_Hans: pod
+    llm_description: pod
+    form: llm
+  - name: cluster
+    type: string
+    required: false
+    label:
+      en_US: cluster
+      zh_Hans: 集群
+    human_description:
+      en_US: cluster
+      zh_Hans: 集群
+    llm_description: cluster
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time(Microsecond)
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_endpoints.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_endpoints.py
@@ -1,0 +1,61 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional, Dict
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class ServiceEndpointsTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: Dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        service = tool_parameters.get('service')
+        cluster = tool_parameters.get('cluster')
+        start_time = tool_parameters.get('startTime')
+        end_time = tool_parameters.get('endTime')
+
+        query_params = {
+            "service": service,
+            "cluster": cluster,
+            "startTime": start_time,
+            "endTime": end_time,
+        }
+
+        try:
+            response = requests.get(
+                f"{dify_config.APO_BACKEND_URL}/api/dataplane/endpoints",
+                params=query_params,
+                timeout=10,
+            )
+            response.raise_for_status()
+
+            result = response.json().get("results", [])
+
+            formatted_data = json.dumps(
+                {
+                    "type": "list",
+                    "display": True,
+                    "data": result,
+                },
+                indent=2,
+            )
+
+            yield self.create_text_message(formatted_data)
+
+        except requests.RequestException as e:
+            yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
+        except json.JSONDecodeError:
+            yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
+        except Exception as e:
+            yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))
+

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_endpoints.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_endpoints.yaml
@@ -1,0 +1,66 @@
+identity:
+  name: dataplane_service_endpoint
+  author: APO
+  label:
+    en_US: Query service's endpoints
+    zh_Hans: 查询服务端点
+description:
+  human:
+    en_US: Query service's endpoints
+    zh_Hans: 查询服务端点
+  llm: Query service's endpoints
+display:
+  type: metric
+  title: Service endpoints
+  unit: number
+parameters:
+  - name: service
+    type: string
+    required: false
+    label:
+      en_US: service
+      zh_Hans: service
+    human_description:
+      en_US: Service name
+      zh_Hans: 服务名
+    llm_description: Service name
+    form: llm
+  - name: cluster
+    type: string
+    required: false
+    label:
+      en_US: cluster
+      zh_Hans: cluster
+      pt_BR: cluster
+    human_description:
+      en_US: cluster
+      zh_Hans: 集群
+      pt_BR: cluster
+    llm_description: cluster
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time(Microsecond)
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_instances.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_instances.py
@@ -1,0 +1,61 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional, Dict
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class ServiceInstancesTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: Dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        service = tool_parameters.get('service')
+        cluster = tool_parameters.get('cluster')
+        start_time = tool_parameters.get("startTime")
+        end_time = tool_parameters.get('endTime')
+
+        query_params = {
+            "service": service,
+            "cluster": cluster,
+            "startTime": start_time,
+            "endTime": end_time,
+        }
+
+        try:
+            response = requests.get(
+                f"{dify_config.APO_BACKEND_URL}/api/dataplane/instances",
+                params=query_params,
+                timeout=10,
+            )
+            response.raise_for_status()
+
+            result = response.json().get("results", {})
+
+            formatted_data = json.dumps(
+                {
+                    "type": "list",
+                    "display": True,
+                    "data": result,
+                },
+                indent=2,
+            )
+
+            yield self.create_text_message(formatted_data)
+
+        except requests.RequestException as e:
+            yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
+        except json.JSONDecodeError:
+            yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
+        except Exception as e:
+            yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))
+

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_instances.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_instances.yaml
@@ -1,0 +1,66 @@
+identity:
+  name: dataplane_service_instances
+  author: APO
+  label:
+    en_US: Query service's instances
+    zh_Hans: 查询服务实例
+description:
+  human:
+    en_US: Query service's instances
+    zh_Hans: 查询服务实例
+  llm: Query service's instances
+display:
+  type: metric
+  title: Service instances
+  unit: number
+parameters:
+  - name: service
+    type: string
+    required: false
+    label:
+      en_US: service
+      zh_Hans: service
+    human_description:
+      en_US: Service name
+      zh_Hans: 服务名
+    llm_description: Service name
+    form: llm
+  - name: cluster
+    type: string
+    required: false
+    label:
+      en_US: cluster
+      zh_Hans: cluster
+      pt_BR: cluster
+    human_description:
+      en_US: cluster
+      zh_Hans: 集群
+      pt_BR: cluster
+    llm_description: cluster
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time(Microsecond)
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_redcharts.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_redcharts.py
@@ -1,0 +1,63 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional, Dict
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class ServiceEndpointsTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: Dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        service = tool_parameters.get('service')
+        cluster = tool_parameters.get("cluster")
+        endpoint = tool_parameters.get('endpoint')
+        start_time = tool_parameters.get('startTime')
+        end_time = tool_parameters.get('endTime')
+
+        query_params = {
+            "service": service,
+            "cluster": cluster,
+            "startTime": start_time,
+            "endTime": end_time,
+            "endpoint": endpoint
+        }
+
+        try:
+            response = requests.get(
+                f"{dify_config.APO_BACKEND_URL}/api/dataplane/redcharts",
+                params=query_params,
+                timeout=10,
+            )
+            response.raise_for_status()
+
+            result = response.json().get("results", {})
+
+            formatted_data = json.dumps(
+                {
+                    "type": "metric",
+                    "display": True,
+                    "data": result,
+                },
+                indent=2,
+            )
+
+            yield self.create_text_message(formatted_data)
+
+        except requests.RequestException as e:
+            yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
+        except json.JSONDecodeError:
+            yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
+        except Exception as e:
+            yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))
+

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_redcharts.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_redcharts.yaml
@@ -1,0 +1,71 @@
+identity:
+  name: dataplane_service_redcharts
+  author: APO
+  label:
+    en_US: Query service's RED charts
+    zh_Hans: 查询服务RED指标
+description:
+  human:
+    en_US: Query service's RED charts
+    zh_Hans: 查询服务RED指标
+  llm: Query service's RED charts
+display:
+  type: metric
+  title: Service RED charts
+  unit: number
+parameters:
+  - name: service
+    type: string
+    required: false
+    label:
+      en_US: service
+      zh_Hans: service
+    human_description:
+      en_US: Service name
+      zh_Hans: 服务名
+    llm_description: Service name
+    form: llm
+  - name: cluster
+    type: string
+    required: false
+    label:
+      en_US: cluster
+      zh_Hans: cluster
+    human_description:
+      en_US: cluster
+      zh_Hans: 集群
+    llm_description: cluster
+    form: llm
+  - name: endpoint
+    type: string
+    required: false
+    label:
+      en_US: endpoint
+      zh_Hans: endpoint
+    human_description:
+      en_US: endpoint
+      zh_Hans: endpoint
+    llm_description: endpoint
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+    llm_description: Data query end time(Microsecond)
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_topology.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_topology.py
@@ -1,0 +1,92 @@
+import json
+from collections.abc import Generator
+from typing import Any, Optional, Dict
+
+import requests
+
+from configs import dify_config
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from libs.apo_utils import APOUtils
+
+
+class ServiceTopologyTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: Dict[str, Any],
+        conversation_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        service = tool_parameters.get('service')
+        cluster = tool_parameters.get('cluster')
+        start_time = tool_parameters.get('startTime')
+        end_time = tool_parameters.get('endTime')
+
+        query_params = {
+            "service": service,
+            "cluster": cluster,
+            "startTime": start_time,
+            "endTime": end_time,
+        }
+
+        try:
+            response = requests.get(
+                f"{dify_config.APO_BACKEND_URL}/api/dataplane/topology",
+                params=query_params,
+                timeout=10,
+            )
+            response.raise_for_status()
+
+            result = response.json().get("results", [])
+
+            current_node = next((node for node in result if node["name"] == service), None)
+            if not current_node:
+                yield self.create_text_message(f"Error: Service {service} not found in topology.")
+                return
+
+            def format_node(node):
+                return {
+                    "endpoint": node["id"],
+                    "group": node["category"],
+                    "isTraced": True,  
+                    "service": node["name"],
+                    "system": node["category"]
+                }
+
+            formatted_current = format_node(current_node)
+
+            formatted_children = [
+                format_node(node)
+                for node in result
+                if node["name"] in current_node["children"]
+            ]
+
+            formatted_parents = [
+                format_node(node)
+                for node in result
+                if node["name"] in current_node["parents"]
+            ]
+
+            formatted_data = json.dumps({
+                "type": "toopology",
+                "display": True,
+                "data": {
+                    "children": formatted_children,
+                    "current": formatted_current,
+                    "parents": formatted_parents,
+                    "rawResp": result
+                    },
+                },
+                indent=2,
+            )
+
+            yield self.create_text_message(formatted_data)
+
+        except requests.RequestException as e:
+            yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
+        except json.JSONDecodeError:
+            yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
+        except Exception as e:
+            yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_topology.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_topology.yaml
@@ -1,0 +1,66 @@
+identity:
+  name: dataplane_service_topology
+  author: APO
+  label:
+    en_US: Query service's topology
+    zh_Hans: 查询服务拓扑
+description:
+  human:
+    en_US: Query service's topology
+    zh_Hans: 查询服务拓扑
+  llm: Query service's topology
+display:
+  type: metric
+  title: Service topology
+  unit: number
+parameters:
+  - name: service
+    type: string
+    required: false
+    label:
+      en_US: service
+      zh_Hans: service
+    human_description:
+      en_US: Service name
+      zh_Hans: 服务名
+    llm_description: Service name
+    form: llm
+  - name: cluster
+    type: string
+    required: false
+    label:
+      en_US: cluster
+      zh_Hans: cluster
+      pt_BR: cluster
+    human_description:
+      en_US: cluster
+      zh_Hans: 集群
+      pt_BR: cluster
+    llm_description: cluster
+    form: llm
+  - name: startTime
+    type: number
+    required: true
+    label:
+      en_US: startTime
+      zh_Hans: startTime
+      pt_BR: startTime
+    human_description:
+      en_US: Data query start time(Microsecond)
+      zh_Hans: 开始时间 (微秒)
+      pt_BR: Data query start time(Microsecond)
+    llm_description: Data query start time(Microsecond)
+    form: llm
+  - name: endTime
+    type: number
+    required: true
+    label:
+      en_US: endTime
+      zh_Hans: endTime
+      pt_BR: endTime
+    human_description:
+      en_US: Data query end time(Microsecond)
+      zh_Hans: 结束时间 (微秒)
+      pt_BR: Data query end time(Microsecond)
+    llm_description: Data query end time(Microsecond)
+    form: llm

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.py
@@ -22,22 +22,16 @@ class ThreadPolarisRunqueueTimeTool(BuiltinTool):
         pod = tool_parameters.get('pod', '')
         node_name = tool_parameters.get('nodeName', '')
         pid = tool_parameters.get('pid', '')
+        container_id = tool_parameters.get('containerId', '')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
-        if node_name == '':
-            node_name = '.*'
-        if pid == '':
-            pid = '.*'
-
         metric_params = {
-            'node_name': node_name,
-            'pid': pid,
+            'node_name': node_name if node_name != '' else '.*',
+            'container_id': container_id if container_id != '' else '.*',
+            'pid': pid if pid != '' else '.*',
+            'pod': pod if pod != '' else '.*',
         }
-        if pod != '':
-            metric_params['pod'] = pod
-        else:
-            metric_params['container_id'] = '.*'
 
         params = {
             'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Runqueue',

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.yaml
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.yaml
@@ -47,6 +47,17 @@ parameters:
       zh_Hans: 进程id
     llm_description: pid
     form: llm
+  - name: containerId 
+    type: string
+    required: False
+    label:
+      en_US: Container ID
+      zh_Hans: 容器ID
+    human_description:
+      en_US: Container ID
+      zh_Hans: 容器ID
+    llm_description: Container ID
+    form: llm
   - name: startTime
     type: number
     required: true

--- a/api/init_data/workflows/zh/可用性告警分析.yml
+++ b/api/init_data/workflows/zh/可用性告警分析.yml
@@ -9,7 +9,7 @@ dependencies:
 - current_identifier: null
   type: package
   value:
-    plugin_unique_identifier: langgenius/deepseek:0.0.5@fd6efd37c2a931911de8ab9ca3ba2da303bef146d45ee87ad896b04b36d09403
+    plugin_unique_identifier: langgenius/openai_api_compatible:0.0.7@f20c7275bbcf055ec5d170dd5128e341986e2dcba5266d08fd080d4bdf2288f6
 kind: app
 version: 0.1.5
 workflow:
@@ -129,42 +129,6 @@ workflow:
       source: '17448784268890'
       sourceHandle: source
       target: '17448784142480'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: llm
-        targetType: variable-aggregator
-      id: 17448784398000-source-1744878466157-target
-      selected: false
-      source: '17448784398000'
-      sourceHandle: source
-      target: '1744878466157'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: llm
-        targetType: variable-aggregator
-      id: 1744878372490-source-1744878466157-target
-      selected: false
-      source: '1744878372490'
-      sourceHandle: source
-      target: '1744878466157'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: variable-aggregator
-        targetType: end
-      id: 1744878466157-source-1744878476249-target
-      selected: false
-      source: '1744878466157'
-      sourceHandle: source
-      target: '1744878476249'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -318,6 +282,281 @@ workflow:
       targetHandle: target
       type: custom
       zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750839702220-source-1750839691646-target
+      source: '1750839702220'
+      sourceHandle: source
+      target: '1750839691646'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750840042580-source-1750839691646-target
+      source: '1750840042580'
+      sourceHandle: source
+      target: '1750839691646'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750840340832-source-1750840042580-target
+      source: '1750840340832'
+      sourceHandle: source
+      target: '1750840042580'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750843294839-source-1750839691646-target
+      source: '1750843294839'
+      sourceHandle: source
+      target: '1750839691646'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750843922551-source-1750839691646-target
+      source: '1750843922551'
+      sourceHandle: source
+      target: '1750839691646'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750843945254-source-1750839691646-target
+      source: '1750843945254'
+      sourceHandle: source
+      target: '1750839691646'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: variable-aggregator
+      id: 17448784398000-source-1750844540721-target
+      source: '17448784398000'
+      sourceHandle: source
+      target: '1750844540721'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: variable-aggregator
+        targetType: variable-aggregator
+      id: 1750844540721-source-1744878466157-target
+      source: '1750844540721'
+      sourceHandle: source
+      target: '1744878466157'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: variable-aggregator
+      id: 1744878372490-source-1750844540721-target
+      source: '1744878372490'
+      sourceHandle: source
+      target: '1750844540721'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750846397041-source-1750843922551-target
+      source: '1750846397041'
+      sourceHandle: source
+      target: '1750843922551'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750846407202-source-1750843945254-target
+      source: '1750846407202'
+      sourceHandle: source
+      target: '1750843945254'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750941439700-source-1750839691646-target
+      source: '1750941439700'
+      sourceHandle: source
+      target: '1750839691646'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: llm
+      id: 1750987639392-source-1750840340832-target
+      source: '1750987639392'
+      sourceHandle: source
+      target: '1750840340832'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: end
+      id: 1751004239868-source-1744878476249-target
+      source: '1751004239868'
+      sourceHandle: source
+      target: '1744878476249'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1751251291730-source-1750843294839-target
+      source: '1751251291730'
+      sourceHandle: source
+      target: '1750843294839'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 1751602453263-source-1751004239868-target
+      source: '1751602453263'
+      sourceHandle: source
+      target: '1751004239868'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: tool
+      id: 1750839691646-source-1751602453263-target
+      source: '1750839691646'
+      sourceHandle: source
+      target: '1751602453263'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: variable-aggregator
+        targetType: if-else
+      id: 1744878466157-source-1751602618703-target
+      source: '1744878466157'
+      sourceHandle: source
+      target: '1751602618703'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: code
+      id: 1751602618703-false-1750839702220-target
+      source: '1751602618703'
+      sourceHandle: 'false'
+      target: '1750839702220'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602618703-false-1750987639392-target
+      source: '1751602618703'
+      sourceHandle: 'false'
+      target: '1750987639392'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602618703-false-1750846397041-target
+      source: '1751602618703'
+      sourceHandle: 'false'
+      target: '1750846397041'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: code
+      id: 1751602618703-false-1750941439700-target
+      source: '1751602618703'
+      sourceHandle: 'false'
+      target: '1750941439700'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602618703-false-1750846407202-target
+      source: '1751602618703'
+      sourceHandle: 'false'
+      target: '1750846407202'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602618703-false-1751251291730-target
+      source: '1751602618703'
+      sourceHandle: 'false'
+      target: '1751251291730'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: end
+      id: 1751602618703-true-1751602687916-target
+      source: '1751602618703'
+      sourceHandle: 'true'
+      target: '1751602687916'
+      targetHandle: target
+      type: custom
+      zIndex: 0
     nodes:
     - data:
         desc: ''
@@ -349,14 +588,20 @@ workflow:
           required: false
           type: paragraph
           variable: nodeName
-      height: 168
+        - label: edition
+          max_length: 48
+          options: []
+          required: false
+          type: paragraph
+          variable: edition
+      height: 194
       id: '1741227526517'
       position:
         x: 30
-        y: 276
+        y: 302
       positionAbsolute:
         x: 30
-        y: 276
+        y: 302
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -373,10 +618,10 @@ workflow:
       id: '1741592094819'
       position:
         x: 942
-        y: 276
+        y: 302
       positionAbsolute:
         x: 942
-        y: 276
+        y: 302
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -396,10 +641,10 @@ workflow:
       id: '1741592144815'
       position:
         x: 1246
-        y: 276
+        y: 302
       positionAbsolute:
         x: 1246
-        y: 276
+        y: 302
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -447,10 +692,10 @@ workflow:
       id: '1742453019576'
       position:
         x: 638
-        y: 276
+        y: 302
       positionAbsolute:
         x: 638
-        y: 276
+        y: 302
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -477,10 +722,14 @@ workflow:
           ]),\n        \"pid\": get_value(data, [\"pid\"]),\n        \"containerId\"\
           : get_value(data, [\"containerId\"]),\n        \"nodeName\": node if node\
           \ else get_value(data, [\"node\", \"src_node\", \"node_name\", \"nodeName\"\
-          ]),\n        \"sourceFrom\": source_from\n    }"
+          ]),\n        \"sourceFrom\": source_from,\n        \"alertEventId\": get_value(data,\
+          \ [\"alertEventId\"]),\n    }"
         code_language: python3
         desc: ''
         outputs:
+          alertEventId:
+            children: null
+            type: string
           alertName:
             children: null
             type: string
@@ -523,11 +772,11 @@ workflow:
       height: 54
       id: '1742807803325'
       position:
-        x: 335.35157092107124
-        y: 276
+        x: 334
+        y: 302
       positionAbsolute:
-        x: 335.35157092107124
-        y: 276
+        x: 334
+        y: 302
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -554,8 +803,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1742807803325'
         - alertName
@@ -565,14 +814,14 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 240
+      height: 246
       id: '17430590082510'
       position:
         x: 942
-        y: 370
+        y: 396
       positionAbsolute:
         x: 942
-        y: 370
+        y: 396
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -693,10 +942,10 @@ workflow:
       id: '1744878296971'
       position:
         x: 2158
-        y: 762
+        y: 812
       positionAbsolute:
         x: 2158
-        y: 762
+        y: 812
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1049,11 +1298,11 @@ workflow:
       height: 54
       id: '1744878298576'
       position:
-        x: 1252.3492475354071
-        y: 422.7880989424209
+        x: 1246
+        y: 510
       positionAbsolute:
-        x: 1252.3492475354071
-        y: 422.7880989424209
+        x: 1246
+        y: 510
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1113,10 +1362,10 @@ workflow:
       id: '1744878352649'
       position:
         x: 1854
-        y: 762
+        y: 812
       positionAbsolute:
         x: 1854
-        y: 762
+        y: 812
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1131,8 +1380,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 615ece65-9193-4bad-a375-d51b67dbaafc
           role: system
@@ -1186,14 +1435,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '1744878372490'
       position:
         x: 2766
-        y: 762
+        y: 812
       positionAbsolute:
         x: 2766
-        y: 762
+        y: 812
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1226,10 +1475,10 @@ workflow:
       id: '1744878389686'
       position:
         x: 1550
-        y: 463
+        y: 492
       positionAbsolute:
         x: 1550
-        y: 463
+        y: 492
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1349,10 +1598,10 @@ workflow:
       id: '17448784142480'
       position:
         x: 2158
-        y: 463
+        y: 492
       positionAbsolute:
         x: 2158
-        y: 463
+        y: 492
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1403,10 +1652,10 @@ workflow:
       id: '17448784268890'
       position:
         x: 1854
-        y: 463
+        y: 492
       positionAbsolute:
         x: 1854
-        y: 463
+        y: 492
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1421,8 +1670,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 615ece65-9193-4bad-a375-d51b67dbaafc
           role: system
@@ -1484,15 +1733,15 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17448784398000'
       position:
         x: 2766
-        y: 463
+        y: 492
       positionAbsolute:
         x: 2766
-        y: 463
-      selected: true
+        y: 492
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -1508,14 +1757,14 @@ workflow:
           - text
         - - '17448784398000'
           - text
-      height: 131
+      height: 130
       id: '1744878466157'
       position:
-        x: 3070
-        y: 463
+        x: 3374
+        y: 492
       positionAbsolute:
-        x: 3070
-        y: 463
+        x: 3374
+        y: 492
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1528,17 +1777,25 @@ workflow:
           - '1744878466157'
           - output
           variable: text
+        - value_selector:
+          - '1751602453263'
+          - text
+          variable: output
+        - value_selector:
+          - '1751004239868'
+          - text
+          variable: alertDirection
         selected: false
         title: 结束
         type: end
-      height: 90
+      height: 142
       id: '1744878476249'
       position:
-        x: 3374
-        y: 463
+        x: 5806
+        y: 836
       positionAbsolute:
-        x: 3374
-        y: 463
+        x: 5806
+        y: 836
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1558,16 +1815,16 @@ workflow:
           \ = []\n    all_logs = []\n    \n    for log in logs or []:\n        content\
           \ = log.get(\"body\", \"\")\n        timestamp = log.get(\"timestamp\")\n\
           \        tags = log.get('tags', {})\n        \n        simplified_log =\
-          \ {\n            \"content\": content,\n            \"timestamp\": timestamp,\n\
+          \ {\n            \"body\": content,\n            \"timestamp\": timestamp,\n\
           \            \"tags\": tags\n        }\n        \n        all_logs.append(simplified_log)\n\
           \        if is_error_log(content):\n            error_logs.append(simplified_log)\n\
           \    \n    result_logs = error_logs if error_logs else all_logs[:100]\n\
-          \    \n    MAX_LENGTH = 80000\n    result_logs_str = json.dumps(result_logs,\
-          \ separators=(\",\", \":\"))\n    \n    while len(result_logs_str) > MAX_LENGTH\
-          \ and len(result_logs) > 0:\n        remove_count = max(1, len(result_logs)\
-          \ // 10)\n        result_logs = result_logs[:-remove_count]\n        result_logs_str\
-          \ = json.dumps(result_logs, separators=(\",\", \":\"))\n    \n    return\
-          \ {\"logs\": result_logs_str}"
+          \    \n    MAX_LENGTH = 50000\n    result_logs_str = json.dumps({\"logs\"\
+          : result_logs}, separators=(\",\", \":\"))\n    \n    while len(result_logs_str)\
+          \ > MAX_LENGTH and len(result_logs) > 0:\n        remove_count = max(1,\
+          \ len(result_logs) // 10)\n        result_logs = result_logs[:-remove_count]\n\
+          \        result_logs_str = json.dumps({\"logs\": result_logs}, separators=(\"\
+          ,\", \":\"))\n    \n    return {\"logs\": result_logs_str}"
         code_language: python3
         desc: ''
         outputs:
@@ -1586,10 +1843,10 @@ workflow:
       id: '1744901266309'
       position:
         x: 2462
-        y: 762
+        y: 812
       positionAbsolute:
         x: 2462
-        y: 762
+        y: 812
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1597,28 +1854,28 @@ workflow:
       width: 244
     - data:
         code: "import re\nfrom typing import List\nimport json\n\nERROR_PATTERNS:\
-          \ List[str] = [\n    r\"\\bERROR\\b\",\n    r\"\\bERR\\b\",\n    r\"\\bEXCEPTION\\\
-          b\",\n    r\"\\bPANIC\\b\",\n    r\"\\bFAIL(?:ED)?\\b\",\n    r\"\\bWRONG\\\
-          b\",\n    r\"\\bFATAL\\b\",\n    r\"\\b500\\b\",\n    r\"\\b5\\d{2}\\b\"\
-          ,\n]\n\nERROR_REGEXES = [re.compile(pat, re.IGNORECASE) for pat in ERROR_PATTERNS]\n\
-          \ndef is_error_log(line: str) -> bool:\n    if not isinstance(line, (str,\
-          \ bytes)):\n        return False\n    for regex in ERROR_REGEXES:\n    \
-          \    if regex.search(line):\n            return True\n    return False\n\
-          \ndef main(data_json: str) -> dict:\n    logs = json.loads(data_json).get(\"\
-          data\", {}).get(\"logContents\", {}).get(\"contents\", [])\n    \n    error_logs\
-          \ = []\n    all_logs = []\n    \n    for log in logs or []:\n        content\
-          \ = log.get(\"body\", \"\")\n        timestamp = log.get(\"timestamp\")\n\
-          \        tags = log.get('tags', {})\n        \n        simplified_log =\
-          \ {\n            \"content\": content,\n            \"timestamp\": timestamp,\n\
-          \            \"tags\": tags\n        }\n        \n        all_logs.append(simplified_log)\n\
-          \        if is_error_log(content):\n            error_logs.append(simplified_log)\n\
-          \    \n    result_logs = error_logs if error_logs else all_logs[:100]\n\
-          \    \n    MAX_LENGTH = 80000\n    result_logs_str = json.dumps(result_logs,\
-          \ separators=(\",\", \":\"))\n    \n    while len(result_logs_str) > MAX_LENGTH\
-          \ and len(result_logs) > 0:\n        remove_count = max(1, len(result_logs)\
-          \ // 10)\n        result_logs = result_logs[:-remove_count]\n        result_logs_str\
-          \ = json.dumps(result_logs, separators=(\",\", \":\"))\n    \n    return\
-          \ {\"logs\": result_logs_str}"
+          \ List[str] = [\n    r\"ERROR\",\n    r\"ERR\",\n    r\"EXCEPTION\",\n \
+          \   r\"PANIC\",\n    r\"FAIL(?:ED)?\",\n    r\"WRONG\",\n    r\"FATAL\"\
+          ,\n    r\"500\",\n    r\"5\\d{2}\",\n]\n\nERROR_REGEXES = [re.compile(pat,\
+          \ re.IGNORECASE) for pat in ERROR_PATTERNS]\n\ndef is_error_log(line: str)\
+          \ -> bool:\n    if not isinstance(line, (str, bytes)):\n        return False\n\
+          \    for regex in ERROR_REGEXES:\n        if regex.search(line):\n     \
+          \       return True\n    return False\n\ndef main(data_json: str) -> dict:\n\
+          \    logs = json.loads(data_json).get(\"data\", {}).get(\"logContents\"\
+          , {}).get(\"contents\", [])\n    \n    error_logs = []\n    all_logs = []\n\
+          \    \n    for log in logs or []:\n        content = log.get(\"body\", \"\
+          \")\n        timestamp = log.get(\"timestamp\")\n        tags = log.get('tags',\
+          \ {})\n        \n        simplified_log = {\n            \"body\": content,\n\
+          \            \"timestamp\": timestamp,\n            \"tags\": tags\n   \
+          \     }\n        \n        all_logs.append(simplified_log)\n        if is_error_log(content):\n\
+          \            error_logs.append(simplified_log)\n    \n    result_logs =\
+          \ error_logs if error_logs else all_logs[:100]\n    \n    MAX_LENGTH = 50000\n\
+          \    result_logs_str = json.dumps({\"logs\": result_logs}, separators=(\"\
+          ,\", \":\"))\n    \n    while len(result_logs_str) > MAX_LENGTH and len(result_logs)\
+          \ > 0:\n        remove_count = max(1, len(result_logs) // 10)\n        result_logs\
+          \ = result_logs[:-remove_count]\n        result_logs_str = json.dumps({\"\
+          logs\": result_logs}, separators=(\",\", \":\"))\n    \n    return {\"logs\"\
+          : result_logs_str}"
         code_language: python3
         desc: ''
         outputs:
@@ -1637,10 +1894,10 @@ workflow:
       id: '17449013347930'
       position:
         x: 2462
-        y: 463
+        y: 492
       positionAbsolute:
         x: 2462
-        y: 463
+        y: 492
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1660,10 +1917,10 @@ workflow:
       id: '1745313574375'
       position:
         x: 1550
-        y: 557
+        y: 586
       positionAbsolute:
         x: 1550
-        y: 557
+        y: 586
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1683,11 +1940,11 @@ workflow:
       height: 54
       id: '1745313576757'
       position:
-        x: 1258.6984950708145
-        y: 557
+        x: 1246
+        y: 622
       positionAbsolute:
-        x: 1258.6984950708145
-        y: 557
+        x: 1246
+        y: 622
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1702,8 +1959,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: qwen3:30b
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 8eba855d-6560-4b17-95ce-79dcdef46512
           role: system
@@ -1717,7 +1974,7 @@ workflow:
             {{#1741227526517.params#}}
 
             请给出一些建议'
-        selected: false
+        selected: true
         title: LLM 3
         type: llm
         variables: []
@@ -1727,11 +1984,11 @@ workflow:
       id: '1745391138767'
       position:
         x: 1246
-        y: 687
+        y: 731
       positionAbsolute:
         x: 1246
-        y: 687
-      selected: false
+        y: 731
+      selected: true
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -1750,16 +2007,1044 @@ workflow:
       id: '1745391142578'
       position:
         x: 1550
-        y: 687
+        y: 716
       positionAbsolute:
         x: 1550
-        y: 687
+        y: 716
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: reportType
+            zh_Hans: 报告类型
+          label:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: reportType
+            zh_Hans: 报告类型
+          llm_description: alert report type
+          max: null
+          min: null
+          name: reportType
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: tags
+            zh_Hans: 报告标签（用于检索）
+          label:
+            en_US: tags
+            ja_JP: tags
+            pt_BR: tags
+            zh_Hans: 报告标签（用于检索）
+          llm_description: alert report tags
+          max: null
+          min: null
+          name: tags
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: overview
+            ja_JP: overview
+            pt_BR: overview
+            zh_Hans: 告警事件总览
+          label:
+            en_US: overview
+            ja_JP: overview
+            pt_BR: overview
+            zh_Hans: 告警事件总览
+          llm_description: overview
+          max: null
+          min: null
+          name: overview
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: topology
+            ja_JP: topology
+            pt_BR: topology
+            zh_Hans: 报告类型
+          label:
+            en_US: topology
+            ja_JP: topology
+            pt_BR: topology
+            zh_Hans: 拓扑数据
+          llm_description: topology data
+          max: null
+          min: null
+          name: topology
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: rootCauseAnalysis
+            ja_JP: rootCauseAnalysis
+            pt_BR: rootCauseAnalysis
+            zh_Hans: 根因分析结论
+          label:
+            en_US: rootCauseAnalysis
+            ja_JP: rootCauseAnalysis
+            pt_BR: rootCauseAnalysis
+            zh_Hans: 根因分析结论
+          llm_description: rootCauseAnalysis
+          max: null
+          min: null
+          name: rootCauseAnalysis
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: suggest
+            ja_JP: suggest
+            pt_BR: suggest
+            zh_Hans: 可行动方向建议
+          label:
+            en_US: suggest
+            ja_JP: suggest
+            pt_BR: suggest
+            zh_Hans: 可行动方向建议
+          llm_description: suggest
+          max: null
+          min: null
+          name: suggest
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: evidence
+            ja_JP: evidence
+            pt_BR: evidence
+            zh_Hans: 根因分析结论
+          label:
+            en_US: evidence
+            ja_JP: evidence
+            pt_BR: evidence
+            zh_Hans: 验证数据
+          llm_description: evidence
+          max: null
+          min: null
+          name: evidence
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        params:
+          evidence: ''
+          overview: ''
+          reportType: ''
+          rootCauseAnalysis: ''
+          suggest: ''
+          tags: ''
+          topology: ''
+        provider_id: apo_analysis
+        provider_name: apo_analysis
+        provider_type: builtin
+        selected: false
+        title: 生成告警分析报告
+        tool_configurations: {}
+        tool_label: 生成告警分析报告
+        tool_name: Generate alert analysis report
+        tool_parameters:
+          evidence:
+            type: mixed
+            value: '{{#1750843294839.result#}}'
+          overview:
+            type: mixed
+            value: '{{#1750840042580.result#}}'
+          reportType:
+            type: mixed
+            value: error
+          rootCauseAnalysis:
+            type: mixed
+            value: '{{#1750843945254.result#}}'
+          suggest:
+            type: mixed
+            value: '{{#1750843922551.result#}}'
+          tags:
+            type: mixed
+            value: '{{#1750839702220.result#}}'
+          topology:
+            type: mixed
+            value: '{{#1750941439700.result#}}'
+        type: tool
+      height: 54
+      id: '1750839691646'
+      position:
+        x: 4894
+        y: 836
+      positionAbsolute:
+        x: 4894
+        y: 836
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\n\ndef main(alertEventId: str) -> dict:\n    data = {\n        \"\
+          alertEventId\": alertEventId\n    }\n    return {\n        \"result\": json.dumps(data),\n\
+          \    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 报告标签
+        type: code
+        variables:
+        - value_selector:
+          - '1742807803325'
+          - alertEventId
+          variable: alertEventId
+      height: 54
+      id: '1750839702220'
+      position:
+        x: 4590
+        y: 492
+      positionAbsolute:
+        x: 4590
+        y: 492
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\n\ndef main(timestamp: int, reason: str, pod: str, node: str, pid:\
+          \ str, containerId: str, service: str, detail: str) -> dict:\n    data =\
+          \ {\n        \"timestamp\": timestamp,\n        \"detail\": detail,\n  \
+          \      \"reason\": reason,\n        \"tags\": {\n            \"service\"\
+          : service,\n            \"pod\": pod,\n            \"nodeName\": node,\n\
+          \            \"pid\": pid,\n            \"containerId\": containerId\n \
+          \       }\n    }\n    return {\n        \"result\": json.dumps(data),\n\
+          \    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 报告总览
+        type: code
+        variables:
+        - value_selector:
+          - '1741227526517'
+          - endTime
+          variable: timestamp
+        - value_selector:
+          - '1750840340832'
+          - text
+          variable: reason
+        - value_selector:
+          - '1742807803325'
+          - pod
+          variable: pod
+        - value_selector:
+          - '1741227526517'
+          - nodeName
+          variable: node
+        - value_selector:
+          - '1742807803325'
+          - pid
+          variable: pid
+        - value_selector:
+          - '1742807803325'
+          - containerId
+          variable: containerId
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+        - value_selector:
+          - '1750987639392'
+          - text
+          variable: detail
+      height: 54
+      id: '1750840042580'
+      position:
+        x: 4590
+        y: 700
+      positionAbsolute:
+        x: 4590
+        y: 700
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: d21add02-97db-4fa3-a6e8-d4387617ce2a
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: 4ca361b5-08c7-461e-b239-648db7bd6815
+          role: user
+          text: "#目的\n根据应用的结论生成根因方向的结论\n#结论数据\n{{#1744878466157.output#}}\n# 时间\n\
+            {{#1741227526517.endTime#}}\n#格式模版参考\n告警报事件结论 \n**事件概述**：\n\n\U0001F6A8\
+            \ 日志错误率升高：15%的请求超过70毫秒，持续5分钟\n\U0001F4CA 异常日志：共128个，90%异常\n**问题分析**\n\n\
+            \U0001F552 日志显示xxx\n \U0001F310 显示xxx可能存在xxxx\n**解决措施**：\n\n\U0001F6E0\
+            ️ 执行xxx\n\U0001F527 检查xxx\n**日志数据**：\n\n⏱️ xx异常\n#输出格式\n格式参考模版，注意换行和空格，确保文本美观输出，简单易懂(使用MarkDown格式的文本)，且不要有其他输出"
+        selected: false
+        title: 格式化结论
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750840340832'
+      position:
+        x: 4286
+        y: 700
+      positionAbsolute:
+        x: 4286
+        y: 700
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\n\ndef main(logs: str, log_text: str) -> dict:\n    logs_raw = json.loads(logs)\n\
+          \    logs_data = {\n        \"type\": \"log\",\n        \"name\": \"应用日志\"\
+          ,\n        \"description\": log_text,\n        \"data\": logs_raw.get(\"\
+          logs\", [])\n    }\n\n    return {\n        \"result\": json.dumps({\n \
+          \           \"evidence\": [logs_data]\n        }),\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 汇总验证数据
+        type: code
+        variables:
+        - value_selector:
+          - '1750844540721'
+          - output
+          variable: logs
+        - value_selector:
+          - '1751251291730'
+          - text
+          variable: log_text
+      height: 54
+      id: '1750843294839'
+      position:
+        x: 4590
+        y: 836
+      positionAbsolute:
+        x: 4590
+        y: 836
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\ndef main(raw_data: str) -> dict:\n    pattern = r'```json\\\
+          n(.*?)\\n```'\n    match = re.search(pattern, raw_data, re.DOTALL)\n\n \
+          \   json_str = match.group(1)\n    rootcause = json.loads(json_str)\n  \
+          \  return {\n        \"result\": json.dumps(rootcause),\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 可行动方向建议
+        type: code
+        variables:
+        - value_selector:
+          - '1750846397041'
+          - text
+          variable: raw_data
+      height: 54
+      id: '1750843922551'
+      position:
+        x: 4590
+        y: 972
+      positionAbsolute:
+        x: 4590
+        y: 972
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\ndef main(raw_data: str) -> dict:\n    pattern = r'```json\\\
+          n(.*?)\\n```'\n    match = re.search(pattern, raw_data, re.DOTALL)\n\n \
+          \   json_str = match.group(1)\n    rootcause = json.loads(json_str)\n  \
+          \  return {\n        \"result\": json.dumps(rootcause),\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 根因方向
+        type: code
+        variables:
+        - value_selector:
+          - '1750846407202'
+          - text
+          variable: raw_data
+      height: 54
+      id: '1750843945254'
+      position:
+        x: 4590
+        y: 1108
+      positionAbsolute:
+        x: 4590
+        y: 1108
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        output_type: string
+        selected: false
+        title: 聚合查询日志
+        type: variable-aggregator
+        variables:
+        - - '1744901266309'
+          - logs
+        - - '17449013347930'
+          - logs
+      height: 130
+      id: '1750844540721'
+      position:
+        x: 3070
+        y: 492
+      positionAbsolute:
+        x: 3070
+        y: 492
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 7694ae43-c744-4e62-9a51-fb4b8d8fe597
+          role: system
+          text: 你是一个可观测性领域的智能助手
+        - id: eaa0bed8-46a2-4c25-aca9-83d0f1105263
+          role: user
+          text: "#目的\n生成建议用户的行动建议\n如执行命令，或者找xxx排除问题\n#结论数据\n{{#1744878466157.output#}}\n\
+            \n\n#格式模版\n```json\n{\"suggest\": [\n        {\n            \"action\"\
+            : \"Add index to payment transaction table.\",\n            \"level\"\
+            : \"high\"\n        },\n        {\n            \"action\": \"Scale up\
+            \ database node CPU resources.\",\n            \"level\": \"medium\"\n\
+            \        }\n    ] }\n```\n#输出格式\njson格式数据，格式参数模版，不要有其他输出"
+        selected: false
+        title: 可行动方向建议
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750846397041'
+      position:
+        x: 4286
+        y: 972
+      positionAbsolute:
+        x: 4286
+        y: 972
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 0e0b95f4-141c-413e-8a29-1b17b745495f
+          role: system
+          text: 你是一个可观测性领域的智能助手
+        - id: 954478ee-4fa8-4750-9abf-14abf2e75271
+          role: user
+          text: "#目的\n根据应用的日志结论生成日志根因方向的结论\n#结论数据\n{{#1744878466157.output#}}\n# 注意\n\
+            type为故障方向\n1第三方依赖（thirdparty），配置问题(config)，代码异常(code)，下游服务错误(downstream)，系统资源异常(system)\n\
+            每个方向直给一个结论即可，不要出现重复\n主要根因方向必须和major结论保持一致，不要不统一\n2且必须给一个有问题的方向(level为major)\n\
+            3 列表必须按照等级排序level从高到低维（major,minor,normal）\n4 cause内容只能为第三方依赖错误，配置问题，代码异常，下游服务调用错误，系统资源\n\
+            #格式模版\n```json\n{\n        \"cause\": \"主要原根因方向\",\n        \"other\"\
+            : [\n            {\n                \"reason\": \"\",\n              \
+            \  \"type\": \"thirdparty\",\n                \"level\": \"major/minor/normal\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"code\",\n                \"level\": \"minor\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"config\",\n                \"level\": \"normal\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"downstream\",\n                \"level\":\
+            \ \"normal\"\n            },\n            {\n                \"reason\"\
+            : \"\",\n                \"type\": \"system\",\n                \"level\"\
+            : \"normal\"\n            }\n        ]\n    }\n```\n#输出格式\ntype只能为第三方依赖（thirdparty），配置问题(config)，代码异常(code)，下游服务错误(downstream)，系统资源异常(system)这几种，不要有其他内容\n\
+            json格式数据，格式参数模版，不要有其他输出"
+        selected: false
+        title: 根因方向结论
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750846407202'
+      position:
+        x: 4286
+        y: 1108
+      positionAbsolute:
+        x: 4286
+        y: 1108
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import requests\nimport json\ndef get_topology(service, cluster, start_time,\
+          \ end_time) -> str:\n        params = {\n          'service': service,\n\
+          \          'cluster': cluster,\n          'startTime': start_time,\n   \
+          \       'endTime': end_time,\n          }\n        resp = requests.get(\"\
+          http://apo-backend-svc:8080\"+ '/api/dataplane/topology', params=params)\n\
+          \        res = {}\n\n\n        query_params = {\n                    'startTime':\
+          \ start_time,\n                    'endTime': end_time,\n              \
+          \      'service': service\n        }\n        response = requests.get(\"\
+          http://apo-backend-svc:8080\"+ '/api/dataplane/redcharts', params=query_params)\n\
+          \        metrics = {}\n        if response.status_code == 200 and response.json()['msg']\
+          \ == '':\n            metrics['latency'] = response.json()['results'][0]['timeseries'][0]['chart']\n\
+          \            metrics['errorRate'] = response.json()['results'][1]['timeseries'][0]['chart']\n\
+          \            metrics['tps'] = response.json()['results'][2]['timeseries'][0]['chart']\n\
+          \        res['current'] = {\n            \"service\": service,\n       \
+          \     \"description\": \"\",\n            \"metrics\": metrics,\n      \
+          \  }\n\n        if resp.status_code == 200 and resp.json()['msg'] == \"\"\
+          :\n            list = resp.json()\n            result = []\n           \
+          \ for item in list['results'] or []:\n                if item[\"name\"]\
+          \ == service:\n                    result = item\n\n            parents\
+          \ = []\n            for p_svc in result['parents']:\n                query_params\
+          \ = {\n                    'startTime': start_time,\n                  \
+          \  'endTime': end_time,\n                    'service': p_svc\n        \
+          \        }\n                response = requests.get(\"http://apo-backend-svc:8080\"\
+          + '/api/dataplane/redcharts', params=query_params)\n                if response.status_code\
+          \ != 200:\n                    continue\n                metrics = {}\n\
+          \                metrics['latency'] = response.json()['results'][0]['timeseries'][0]['chart']\n\
+          \                metrics['errorRate'] = response.json()['results'][1]['timeseries'][0]['chart']\n\
+          \                metrics['tps'] = response.json()['results'][2]['timeseries'][0]['chart']\n\
+          \                parents.append({\n                    'service': p_svc,\n\
+          \                    'description': \"\",\n                    'metrics':\
+          \ metrics,\n                })\n            \n            children = []\n\
+          \            for c_svc in result['children']:\n                query_params\
+          \ = {\n                    'startTime': start_time,\n                  \
+          \  'endTime': end_time,\n                    'service': c_svc\n        \
+          \        }\n                response = requests.get(\"http://apo-backend-svc:8080\"\
+          + '/api/dataplane/redcharts', params=query_params)\n                if response.status_code\
+          \ != 200 or response.json()['msg'] != '':\n                    continue\n\
+          \                metrics = {}\n                metrics['latency'] = response.json()['results'][0]['timeseries'][0]['chart']\n\
+          \                metrics['errorRate'] = response.json()['results'][1]['timeseries'][0]['chart']\n\
+          \                metrics['tps'] = response.json()['results'][2]['timeseries'][0]['chart']\n\
+          \                children.append({\n                    'service': c_svc,\n\
+          \                    'description': \"\",\n                    'metrics':\
+          \ metrics,\n                })\n            \n            res['children']\
+          \ = children\n            res['parents'] = parents\n            return json.dumps(res)\n\
+          \n\ndef main(service: str, startTime: int, endTime: int) -> dict:\n    rc\
+          \ = get_topology(service, \"\", startTime, endTime)\n    if rc == None:\n\
+          \        rc = \"{}\"\n    return {\n        \"result\": rc,\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 获取拓扑
+        type: code
+        variables:
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+        - value_selector:
+          - '1741227526517'
+          - startTime
+          variable: startTime
+        - value_selector:
+          - '1741227526517'
+          - endTime
+          variable: endTime
+      height: 54
+      id: '1750941439700'
+      position:
+        x: 4590
+        y: 1202
+      positionAbsolute:
+        x: 4590
+        y: 1202
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 45ec55b5-ae91-45b8-989c-83f81cee1712
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: 2832e05f-6966-49d9-9697-77bde92736a9
+          role: user
+          text: "#目的\n根据应用的结论生成当前情况的描述\n使用结论内的数据，回答简洁易懂\n#结论数据\n{{#1744878466157.output#}}\n\
+            # 时间\n{{#1741227526517.endTime#}}\n#格式模版参考\n告警报事件结论 \n**事件概述**：\n当前告警事件为XXXX\
+            \ (简洁，不要有其他内容)\n**问题分析**\n初步分析是XXX方向（通过日志内容总结），不要有其他内容，给出方向即可\n**解决措施**：\n\
+            - 执行XXXX命令（必须和故障方向有关）\n\n#输出格式\n格式参考模版，注意换行和空格，确保文本美观输出，简单易懂(使用MarkDown格式的文本)，且不要有其他输出"
+        selected: false
+        title: 总结
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750987639392'
+      position:
+        x: 3982
+        y: 700
+      positionAbsolute:
+        x: 3982
+        y: 700
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: d33542e3-ac5c-48f1-970b-fa7ab0ffd0ef
+          role: system
+          text: ''
+        - id: a070588b-7b1e-453e-8994-1e1bb6b4593c
+          role: user
+          text: '#目的
+
+            从故障结论中提取故障方向
+
+            # 注意
+
+            根据结论的内容划分故障方向
+
+            1 如果网络链路rtt正常，网络方向给出下游依赖问题
+
+            2 日志告警给出日志错误
+
+            3 基础设施告警，给出资源问题
+
+            #结论数据
+
+            {{#1744878466157.output#}}
+
+            #输出内容
+
+            故障方向，只输出四个字就好 （如网络方向，下游依赖问题，cpu方向， 日志错误等）'
+        selected: false
+        title: LLM 8
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1751004239868'
+      position:
+        x: 5502
+        y: 836
+      positionAbsolute:
+        x: 5502
+        y: 836
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - role: system
+          text: 你是一个可观测性领域智能助手，帮助用户解决问题
+        - role: user
+          text: '# 目的
+
+            输出当前日志数据的情况，输出字数100左右，尽量简洁名了
+
+            # 日志数据
+
+            {{#1750844540721.output#}}
+
+            #输出
+
+            从日志中可以看出xxxx'
+        selected: false
+        title: 日志总结
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1751251291730'
+      position:
+        x: 4286
+        y: 836
+      positionAbsolute:
+        x: 4286
+        y: 836
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: alertEventId
+            ja_JP: alertEventId
+            pt_BR: alertEventId
+            zh_Hans: 报告类型
+          label:
+            en_US: alertEventId
+            ja_JP: alertEventId
+            pt_BR: alertEventId
+            zh_Hans: 告警事件ID
+          llm_description: alertEventId
+          max: null
+          min: null
+          name: alertEventId
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportText
+            ja_JP: reportText
+            pt_BR: reportText
+            zh_Hans: 报告简要文本
+          label:
+            en_US: reportText
+            ja_JP: reportText
+            pt_BR: reportText
+            zh_Hans: 报告简要文本
+          llm_description: reportText
+          max: null
+          min: null
+          name: reportText
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: frontPrefix
+            ja_JP: frontPrefix
+            pt_BR: frontPrefix
+            zh_Hans: 报告访问地址
+          label:
+            en_US: frontPrefix
+            ja_JP: frontPrefix
+            pt_BR: frontPrefix
+            zh_Hans: 报告访问地址
+          llm_description: frontPrefix
+          max: null
+          min: null
+          name: frontPrefix
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Start timestamp in microseconds
+            ja_JP: Start timestamp in microseconds
+            pt_BR: Start timestamp in microseconds
+            zh_Hans: 查询开始时间（微秒）
+          label:
+            en_US: Start Time
+            ja_JP: Start Time
+            pt_BR: Start Time
+            zh_Hans: 开始时间
+          llm_description: Microsecond timestamp for start time
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: End timestamp in microseconds
+            ja_JP: End timestamp in microseconds
+            pt_BR: End timestamp in microseconds
+            zh_Hans: 查询结束时间（微秒）
+          label:
+            en_US: End Time
+            ja_JP: End Time
+            pt_BR: End Time
+            zh_Hans: 结束时间
+          llm_description: Microsecond timestamp for end time
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          alertEventId: ''
+          endTime: ''
+          frontPrefix: ''
+          reportText: ''
+          startTime: ''
+        provider_id: apo_analysis
+        provider_name: apo_analysis
+        provider_type: builtin
+        selected: false
+        title: 获取告警分析报告链接
+        tool_configurations: {}
+        tool_label: 获取告警分析报告链接
+        tool_name: get alert report url
+        tool_parameters:
+          alertEventId:
+            type: mixed
+            value: '{{#1742807803325.alertEventId#}}'
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          reportText:
+            type: mixed
+            value: 当前应用日志错误数升高\n详细报告内容\n
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+        type: tool
+      height: 54
+      id: '1751602453263'
+      position:
+        x: 5198
+        y: 836
+      positionAbsolute:
+        x: 5198
+        y: 836
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        cases:
+        - case_id: 'true'
+          conditions:
+          - comparison_operator: is
+            id: cbd77e4f-1f53-4d83-b9fe-413de4db0078
+            value: ce
+            varType: string
+            variable_selector:
+            - '1741227526517'
+            - edition
+          id: 'true'
+          logical_operator: and
+        desc: ''
+        selected: false
+        title: 条件分支 2
+        type: if-else
+      height: 126
+      id: '1751602618703'
+      position:
+        x: 3678
+        y: 492
+      positionAbsolute:
+        x: 3678
+        y: 492
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        outputs:
+        - value_selector:
+          - '1744878466157'
+          - output
+          variable: text
+        selected: false
+        title: 结束 5
+        type: end
+      height: 90
+      id: '1751602687916'
+      position:
+        x: 3982
+        y: 570
+      positionAbsolute:
+        x: 3982
+        y: 570
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
     viewport:
-      x: -349.98141784261156
-      y: 52.56501584401272
-      zoom: 0.48872262970053
+      x: 47.03146648242307
+      y: 94.5672153955509
+      zoom: 0.3941309919597938

--- a/api/init_data/workflows/zh/告警事件分类.yml
+++ b/api/init_data/workflows/zh/告警事件分类.yml
@@ -9,7 +9,7 @@ dependencies:
 - current_identifier: null
   type: package
   value:
-    plugin_unique_identifier: langgenius/deepseek:0.0.5@fd6efd37c2a931911de8ab9ca3ba2da303bef146d45ee87ad896b04b36d09403
+    plugin_unique_identifier: langgenius/openai_api_compatible:0.0.7@f20c7275bbcf055ec5d170dd5128e341986e2dcba5266d08fd080d4bdf2288f6
 kind: app
 version: 0.1.5
 workflow:
@@ -30,13 +30,6 @@ workflow:
       - local_file
       - remote_url
       enabled: false
-      fileUploadConfig:
-        audio_file_size_limit: 50
-        batch_count_limit: 5
-        file_size_limit: 15
-        image_file_size_limit: 10
-        video_file_size_limit: 100
-        workflow_file_upload_limit: 10
       image:
         enabled: false
         number_limits: 3
@@ -208,17 +201,17 @@ workflow:
       positionAbsolute:
         x: 30
         y: 264.5
-      selected: true
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         code: "import re\n\nLATENCY = \"request_latency\"\nAVAILABILITY = \"service_availability\"\
           \nINFRASTRUCTURE = \"infrastructure\"\nUNKNOWN = \"unknown\"\n\nclass AlertClassifier:\n\
           \    def __init__(self):\n        \n        self.rules = {\n           \
           \ AVAILABILITY: [\n                r'\\b(downtime|unavailable|offline|crash|failure|服务不可用|无法访问|中断|停止|error\
-          \ rate|error count|killed)\\b',\n                r'\\b.*(service|应用|系统|request|log|container|请求|日志).*(不可用|失败|错误率|宕机|终止|错误).*\\\
+          \ rate|error count|killed)\\b',\n                r'\\b.*(service|应用|系统|request|log|container|请求|日志|错误).*(不可用|失败|错误率|宕机|终止|错误|日志).*\\\
           b',\n                r'\\b(5xx|503|502|404)\\b',\n            ],\n     \
           \       INFRASTRUCTURE: [\n                r'\\b(network.*rtt|rtt.*latency)\\\
           b',  # match network rtt\n                r'\\b.*(cpu|memory|disk|network|bandwidth|storage|资源|rtt|cpu_cfs_throttled|硬件负载|容量|磁盘|吞吐量|文件描述符|throughput|read\
@@ -268,7 +261,7 @@ workflow:
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         desc: ''
         outputs:
@@ -280,10 +273,14 @@ workflow:
           - '1745304707998'
           - result
           variable: workflowId
+        - value_selector:
+          - '1745304707998'
+          - apikey
+          variable: workflowApiKey
         selected: false
         title: end
         type: end
-      height: 114
+      height: 140
       id: '1745224862564'
       position:
         x: 1848
@@ -295,7 +292,7 @@ workflow:
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         cases:
         - case_id: 'true'
@@ -325,7 +322,7 @@ workflow:
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         desc: ''
         output_type: string
@@ -349,21 +346,26 @@ workflow:
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         code: "\ndef main(arg1: str) -> dict:\n    res = \"a2d4d3aa-3401-4393-859e-df051bdd5cd1\"\
-          \n    match arg1:\n        case \"request_latency\":\n            res =\
-          \ \"a2d4d3aa-3401-4393-859e-df051bdd5cd1\"\n        case \"service_availability\"\
-          :\n            res = \"40dea201-7aa4-4e27-865b-6ebeab91a0c3\"\n        case\
-          \ \"infrastructure\":\n            res = \"f514d742-6043-498e-98f1-ab03cbcb0250\"\
-          \n    return {\n        \"result\": res,\n    }\n"
+          \n    apikey = \"app-JDtZH1DfQtQb1SjzC3as680C\"\n    match arg1:\n     \
+          \   case \"request_latency\":\n            res = \"a2d4d3aa-3401-4393-859e-df051bdd5cd1\"\
+          \n        case \"service_availability\":\n            res = \"40dea201-7aa4-4e27-865b-6ebeab91a0c3\"\
+          \n            apikey = \"app-LmlwNJaxmSWRCd2DCk6MhkDd\"\n        case \"\
+          infrastructure\":\n            res = \"f514d742-6043-498e-98f1-ab03cbcb0250\"\
+          \n            apikey = \"app-aIEZTMcRkOicrNK1ZegT80wQ\"\n    return {\n\
+          \        \"result\": res,\n        \"apikey\": apikey,\n    }\n"
         code_language: python3
         desc: ''
         outputs:
+          apikey:
+            children: null
+            type: string
           result:
             children: null
             type: string
-        selected: false
+        selected: true
         title: get worflow_id
         type: code
         variables:
@@ -374,16 +376,16 @@ workflow:
       height: 52
       id: '1745304707998'
       position:
-        x: 1545
+        x: 1557.7717573272403
         y: 264.5
       positionAbsolute:
-        x: 1545
+        x: 1557.7717573272403
         y: 264.5
-      selected: false
+      selected: true
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         classes:
         - id: '1'
@@ -401,8 +403,8 @@ workflow:
           completion_params:
             temperature: 0.1
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1745224781828'
         - alertName
@@ -415,16 +417,16 @@ workflow:
       height: 238
       id: '1747310030413'
       position:
-        x: 939
-        y: 413.5
+        x: 669.4535410854317
+        y: 578.1887220886825
       positionAbsolute:
-        x: 939
-        y: 413.5
+        x: 669.4535410854317
+        y: 578.1887220886825
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         desc: ''
         outputs:
@@ -438,16 +440,16 @@ workflow:
       height: 88
       id: '1748308923990'
       position:
-        x: 1545
-        y: 415.5
+        x: 1538.397216052539
+        y: 645.3250337970137
       positionAbsolute:
-        x: 1545
-        y: 415.5
+        x: 1538.397216052539
+        y: 645.3250337970137
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     - data:
         desc: ''
         selected: false
@@ -462,17 +464,17 @@ workflow:
       height: 52
       id: '1748308934593'
       position:
-        x: 1242
-        y: 472
+        x: 1139.825941382076
+        y: 702.3372804248803
       positionAbsolute:
-        x: 1242
-        y: 472
+        x: 1139.825941382076
+        y: 702.3372804248803
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
-      width: 243
+      width: 242
     viewport:
-      x: -252.36708811682195
-      y: 12.679066648163143
-      zoom: 0.6171138784972152
+      x: -925.5766014054602
+      y: -62.88294380286851
+      zoom: 0.9424356123466737

--- a/api/init_data/workflows/zh/告警有效性确认.yml
+++ b/api/init_data/workflows/zh/告警有效性确认.yml
@@ -9,7 +9,7 @@ dependencies:
 - current_identifier: null
   type: package
   value:
-    plugin_unique_identifier: langgenius/deepseek:0.0.5@fd6efd37c2a931911de8ab9ca3ba2da303bef146d45ee87ad896b04b36d09403
+    plugin_unique_identifier: langgenius/openai_api_compatible:0.0.7@f20c7275bbcf055ec5d170dd5128e341986e2dcba5266d08fd080d4bdf2288f6
 kind: app
 version: 0.1.5
 workflow:
@@ -206,18 +206,6 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: llm
-        targetType: question-classifier
-      id: 1742366141890-source-1742366303110-target
-      selected: false
-      source: '1742366141890'
-      sourceHandle: source
-      target: '1742366303110'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: question-classifier
         targetType: variable-aggregator
       id: 1742366303110-1-1741311394752-target
@@ -315,36 +303,12 @@ workflow:
     - data:
         isInIteration: false
         sourceType: tool
-        targetType: variable-aggregator
-      id: 17424344697090-source-1741162531836-target
-      selected: false
-      source: '17424344697090'
-      sourceHandle: source
-      target: '1741162531836'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
         targetType: tool
       id: 1741328197695-source-17424345080000-target
       selected: false
       source: '1741328197695'
       sourceHandle: source
       target: '17424345080000'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: variable-aggregator
-      id: 17424345080000-source-1741162531836-target
-      selected: false
-      source: '17424345080000'
-      sourceHandle: source
-      target: '1741162531836'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -1116,6 +1080,72 @@ workflow:
       targetHandle: target
       type: custom
       zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: variable-aggregator
+      id: 1742366141890-source-1750745724225-target
+      source: '1742366141890'
+      sourceHandle: source
+      target: '1750745724225'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: variable-aggregator
+        targetType: question-classifier
+      id: 1750745724225-source-1742366303110-target
+      source: '1750745724225'
+      sourceHandle: source
+      target: '1742366303110'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 17424344697090-source-1750745788772-target
+      source: '17424344697090'
+      sourceHandle: source
+      target: '1750745788772'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: variable-aggregator
+      id: 1750745788772-source-1750745724225-target
+      source: '1750745788772'
+      sourceHandle: source
+      target: '1750745724225'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 17424345080000-source-1751515586426-target
+      source: '17424345080000'
+      sourceHandle: source
+      target: '1751515586426'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: variable-aggregator
+      id: 1751515586426-source-1750745724225-target
+      source: '1751515586426'
+      sourceHandle: source
+      target: '1750745724225'
+      targetHandle: target
+      type: custom
+      zIndex: 0
     nodes:
     - data:
         desc: ''
@@ -1170,10 +1200,10 @@ workflow:
       id: '1741157526222'
       position:
         x: 30
-        y: 638
+        y: 637
       positionAbsolute:
         x: 30
-        y: 638
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1192,11 +1222,11 @@ workflow:
       height: 90
       id: '1741157560922'
       position:
-        x: 3982
-        y: 2147
+        x: 4258
+        y: 2040
       positionAbsolute:
-        x: 3982
-        y: 2147
+        x: 4258
+        y: 2040
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1299,8 +1329,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1741157526222'
         - alert
@@ -1310,14 +1340,14 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 876
+      height: 882
       id: '1741158559444'
       position:
-        x: 1550
-        y: 638
+        x: 1540
+        y: 637
       positionAbsolute:
-        x: 1550
-        y: 638
+        x: 1540
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1360,14 +1390,14 @@ workflow:
           - text
         - - '1748272742118'
           - text
-      height: 417
+      height: 416
       id: '1741162531836'
       position:
-        x: 2462
-        y: 2147
+        x: 2446
+        y: 1859
       positionAbsolute:
-        x: 2462
-        y: 2147
+        x: 2446
+        y: 1859
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1386,14 +1416,14 @@ workflow:
           - class_name
         - - '1744339618961'
           - abnormal
-      height: 153
+      height: 152
       id: '1741311394752'
       position:
-        x: 3678
-        y: 2147
+        x: 3958.478468077761
+        y: 2040
       positionAbsolute:
-        x: 3678
-        y: 2147
+        x: 3958.478468077761
+        y: 2040
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1534,11 +1564,11 @@ workflow:
       height: 54
       id: '1741328045214'
       position:
-        x: 1854
-        y: 3065
+        x: 1842
+        y: 3108
       positionAbsolute:
-        x: 1854
-        y: 3065
+        x: 1842
+        y: 3108
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1679,11 +1709,11 @@ workflow:
       height: 54
       id: '1741328076453'
       position:
-        x: 1854
-        y: 638
+        x: 1842
+        y: 637
       positionAbsolute:
-        x: 1854
-        y: 638
+        x: 1842
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1833,11 +1863,11 @@ workflow:
       height: 54
       id: '1741328197695'
       position:
-        x: 1854
-        y: 1677
+        x: 2311.6789223996607
+        y: 2514.7380521199802
       positionAbsolute:
-        x: 1854
-        y: 1677
+        x: 2311.6789223996607
+        y: 2514.7380521199802
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1950,11 +1980,11 @@ workflow:
       height: 54
       id: '1741328213545'
       position:
-        x: 1854
-        y: 1771
+        x: 1842
+        y: 1672
       positionAbsolute:
-        x: 1854
-        y: 1771
+        x: 1842
+        y: 1672
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2067,11 +2097,11 @@ workflow:
       height: 54
       id: '1741328346220'
       position:
-        x: 1854
-        y: 1865
+        x: 1842
+        y: 1764
       positionAbsolute:
-        x: 1854
-        y: 1865
+        x: 1842
+        y: 1764
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2184,11 +2214,11 @@ workflow:
       height: 54
       id: '1741328423453'
       position:
-        x: 1854
-        y: 1959
+        x: 1842
+        y: 1856
       positionAbsolute:
-        x: 1854
-        y: 1959
+        x: 1842
+        y: 1856
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2301,11 +2331,11 @@ workflow:
       height: 54
       id: '1741328466394'
       position:
-        x: 1854
-        y: 2053
+        x: 1842
+        y: 1948
       positionAbsolute:
-        x: 1854
-        y: 2053
+        x: 1842
+        y: 1948
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2418,11 +2448,11 @@ workflow:
       height: 54
       id: '1741328742817'
       position:
-        x: 1854
-        y: 2147
+        x: 1842
+        y: 2040
       positionAbsolute:
-        x: 1854
-        y: 2147
+        x: 1842
+        y: 2040
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2535,11 +2565,11 @@ workflow:
       height: 54
       id: '1741328773213'
       position:
-        x: 1854
-        y: 2241
+        x: 1842
+        y: 2132
       positionAbsolute:
-        x: 1854
-        y: 2241
+        x: 1842
+        y: 2132
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2652,11 +2682,11 @@ workflow:
       height: 54
       id: '1741328799030'
       position:
-        x: 1854
-        y: 2335
+        x: 1842
+        y: 2224
       positionAbsolute:
-        x: 1854
-        y: 2335
+        x: 1842
+        y: 2224
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2797,11 +2827,11 @@ workflow:
       height: 54
       id: '1741329632798'
       position:
-        x: 1854
-        y: 1583
+        x: 2446
+        y: 2740
       positionAbsolute:
-        x: 1854
-        y: 1583
+        x: 2446
+        y: 2740
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2816,8 +2846,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: c981a70d-9ebb-4f03-949a-8d78826f9bda
           role: system
@@ -2834,7 +2864,7 @@ workflow:
 
             2. 告警有效性确认：结合告警事件，判断当前告警是否有效。
 
-            如果MetricsData持续上升或处于高位，则认为告警有效。
+            如果MetricsData持续上升，则认为告警有效。
 
             如果处于波动状态，即偶尔上升，但随后下降，则认为告警无效。
 
@@ -2869,14 +2899,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '1742366141890'
       position:
-        x: 3070
-        y: 2147
+        x: 3050
+        y: 2040
       positionAbsolute:
-        x: 3070
-        y: 2147
+        x: 3050
+        y: 2040
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2905,8 +2935,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1742366141890'
         - text
@@ -2916,14 +2946,14 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 168
+      height: 174
       id: '1742366303110'
       position:
-        x: 3374
-        y: 2147
+        x: 3654
+        y: 2040
       positionAbsolute:
-        x: 3374
-        y: 2147
+        x: 3654
+        y: 2040
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2959,14 +2989,14 @@ workflow:
           - '1741157526222'
           - endTime
           variable: arg2
-      height: 79
+      height: 80
       id: '1742433446760'
       position:
-        x: 638
-        y: 638
+        x: 634
+        y: 637
       positionAbsolute:
-        x: 638
-        y: 638
+        x: 634
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3107,11 +3137,11 @@ workflow:
       height: 54
       id: '17424339242280'
       position:
-        x: 2158
-        y: 3065
+        x: 2144
+        y: 3108
       positionAbsolute:
-        x: 2158
-        y: 3065
+        x: 2144
+        y: 3108
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3154,14 +3184,14 @@ workflow:
           - text
         - - '17482728139340'
           - text
-      height: 417
+      height: 416
       id: '1742434016239'
       position:
-        x: 2766
-        y: 2147
+        x: 2748
+        y: 1859
       positionAbsolute:
-        x: 2766
-        y: 2147
+        x: 2748
+        y: 1859
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3302,11 +3332,11 @@ workflow:
       height: 54
       id: '17424342365860'
       position:
-        x: 2158
-        y: 638
+        x: 2144
+        y: 637
       positionAbsolute:
-        x: 2158
-        y: 638
+        x: 2144
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3447,11 +3477,11 @@ workflow:
       height: 54
       id: '17424344697090'
       position:
-        x: 2158
-        y: 1583
+        x: 2748
+        y: 2740
       positionAbsolute:
-        x: 2158
-        y: 1583
+        x: 2748
+        y: 2740
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3601,11 +3631,11 @@ workflow:
       height: 54
       id: '17424345080000'
       position:
-        x: 2158
-        y: 1677
+        x: 2692.2153979484565
+        y: 2505.498466761298
       positionAbsolute:
-        x: 2158
-        y: 1677
+        x: 2692.2153979484565
+        y: 2505.498466761298
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3718,11 +3748,11 @@ workflow:
       height: 54
       id: '17424345315500'
       position:
-        x: 2158
-        y: 1771
+        x: 2144
+        y: 1672
       positionAbsolute:
-        x: 2158
-        y: 1771
+        x: 2144
+        y: 1672
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3835,11 +3865,11 @@ workflow:
       height: 54
       id: '17424345826170'
       position:
-        x: 2158
-        y: 1865
+        x: 2144
+        y: 1764
       positionAbsolute:
-        x: 2158
-        y: 1865
+        x: 2144
+        y: 1764
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3952,11 +3982,11 @@ workflow:
       height: 54
       id: '17424346884650'
       position:
-        x: 2158
-        y: 1959
+        x: 2144
+        y: 1856
       positionAbsolute:
-        x: 2158
-        y: 1959
+        x: 2144
+        y: 1856
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4069,11 +4099,11 @@ workflow:
       height: 54
       id: '17424347242840'
       position:
-        x: 2158
-        y: 2053
+        x: 2144
+        y: 1948
       positionAbsolute:
-        x: 2158
-        y: 2053
+        x: 2144
+        y: 1948
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4186,11 +4216,11 @@ workflow:
       height: 54
       id: '17424348206030'
       position:
-        x: 2158
-        y: 2147
+        x: 2144
+        y: 2040
       positionAbsolute:
-        x: 2158
-        y: 2147
+        x: 2144
+        y: 2040
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4303,11 +4333,11 @@ workflow:
       height: 54
       id: '17424348526540'
       position:
-        x: 2158
-        y: 2241
+        x: 2144
+        y: 2132
       positionAbsolute:
-        x: 2158
-        y: 2241
+        x: 2144
+        y: 2132
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4420,11 +4450,11 @@ workflow:
       height: 54
       id: '17424348570980'
       position:
-        x: 2158
-        y: 2335
+        x: 2144
+        y: 2224
       positionAbsolute:
-        x: 2158
-        y: 2335
+        x: 2144
+        y: 2224
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4480,11 +4510,11 @@ workflow:
       height: 54
       id: '1742806924635'
       position:
-        x: 334
-        y: 638
+        x: 332
+        y: 637
       positionAbsolute:
-        x: 334
-        y: 638
+        x: 332
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4651,11 +4681,11 @@ workflow:
       height: 54
       id: '1742979394268'
       position:
-        x: 1854
-        y: 2617
+        x: 1842
+        y: 2500
       positionAbsolute:
-        x: 1854
-        y: 2617
+        x: 1842
+        y: 2500
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4822,11 +4852,11 @@ workflow:
       height: 54
       id: '1742979595004'
       position:
-        x: 1854
-        y: 2711
+        x: 1842
+        y: 2592
       positionAbsolute:
-        x: 1854
-        y: 2711
+        x: 1842
+        y: 2592
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4993,11 +5023,11 @@ workflow:
       height: 54
       id: '17429797453350'
       position:
-        x: 1854
-        y: 2429
+        x: 1842
+        y: 2316
       positionAbsolute:
-        x: 1854
-        y: 2429
+        x: 1842
+        y: 2316
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5164,11 +5194,11 @@ workflow:
       height: 54
       id: '17429797664440'
       position:
-        x: 2158
-        y: 2429
+        x: 2144
+        y: 2316
       positionAbsolute:
-        x: 2158
-        y: 2429
+        x: 2144
+        y: 2316
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5306,11 +5336,11 @@ workflow:
       height: 54
       id: '1742979828391'
       position:
-        x: 1854
-        y: 2523
+        x: 1842
+        y: 2408
       positionAbsolute:
-        x: 1854
-        y: 2523
+        x: 1842
+        y: 2408
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5448,11 +5478,11 @@ workflow:
       height: 54
       id: '17429798797920'
       position:
-        x: 2158
-        y: 2523
+        x: 2144
+        y: 2408
       positionAbsolute:
-        x: 2158
-        y: 2523
+        x: 2144
+        y: 2408
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5619,11 +5649,11 @@ workflow:
       height: 54
       id: '17429835599060'
       position:
-        x: 2158
-        y: 2617
+        x: 2144
+        y: 2500
       positionAbsolute:
-        x: 2158
-        y: 2617
+        x: 2144
+        y: 2500
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5790,11 +5820,11 @@ workflow:
       height: 54
       id: '17429835940550'
       position:
-        x: 2158
-        y: 2711
+        x: 2144
+        y: 2592
       positionAbsolute:
-        x: 2158
-        y: 2711
+        x: 2144
+        y: 2592
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5963,11 +5993,11 @@ workflow:
       height: 54
       id: '1744093337863'
       position:
-        x: 1854
-        y: 2917
+        x: 1842
+        y: 2962
       positionAbsolute:
-        x: 1854
-        y: 2917
+        x: 1842
+        y: 2962
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5986,11 +6016,11 @@ workflow:
       height: 90
       id: '1744093385250'
       position:
-        x: 2766
-        y: 3080.5
+        x: 2748
+        y: 2944
       positionAbsolute:
-        x: 2766
-        y: 3080.5
+        x: 2748
+        y: 2944
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6005,8 +6035,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: a1de005a-fbe2-44a6-9b2c-bb021ae6b3a4
           role: system
@@ -6034,15 +6064,15 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '1744093428286'
       position:
-        x: 2158
-        y: 2899
+        x: 2144
+        y: 2944
       positionAbsolute:
-        x: 2158
-        y: 2899
-      selected: true
+        x: 2144
+        y: 2944
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -6057,11 +6087,11 @@ workflow:
       height: 54
       id: '1744093531084'
       position:
-        x: 2462
-        y: 3098.5
+        x: 2446
+        y: 2962
       positionAbsolute:
-        x: 2462
-        y: 3098.5
+        x: 2446
+        y: 2962
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6288,11 +6318,11 @@ workflow:
       height: 54
       id: '1744339618961'
       position:
-        x: 3070
-        y: 3083
+        x: 3146.917656182187
+        y: 2982.1617777841084
       positionAbsolute:
-        x: 3070
-        y: 3083
+        x: 3146.917656182187
+        y: 2982.1617777841084
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6315,11 +6345,11 @@ workflow:
       height: 116
       id: '1744343454355'
       position:
-        x: 3678
-        y: 3083.5
+        x: 3701.829492661339
+        y: 3182.7384192889735
       positionAbsolute:
-        x: 3678
-        y: 3083.5
+        x: 3701.829492661339
+        y: 3182.7384192889735
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6389,40 +6419,57 @@ workflow:
           \ \"No historical data available.\", 0\n    \n    # 统计范围和峰值\n    min_val\
           \ = min(values)\n    max_val = max(values)\n    avg_val = sum(values) /\
           \ len(values)\n    high_values = sorted([v for v in values if v > avg_val\
-          \ * 2], reverse=True)\n    \n    description = [\n        \"历史数据显示该指标通常维持在很低的水平：\"\
+          \ * 1.2], reverse=True)\n    \n    description = [\n        \"历史数据显示该指标通常维持在很低的水平：\"\
           ,\n        f\"大多数值在{avg_val:.6f} - {avg_val * 1.2:.6f}之间\",\n        f\"\
           偶尔有较高值({', '.join(f'{v:.3f}' for v in high_values[:2])})但持续时间很短\"\n    ]\n\
           \    \n    return description, avg_val\n\ndef analyze_latency(past_24h,\
           \ recent_15m):\n    \"\"\"综合分析并生成报告\"\"\"\n    # 分析15分钟趋势\n    trend_desc\
-          \ = analyze_trend(recent_15m)\n    \n    # 分析历史数据\n    history_desc, history_max\
-          \ = analyze_history(past_24h)\n    \n    # 获取15分钟内的最大值和最后几个点\n    recent_values\
+          \ = analyze_trend(recent_15m)\n    \n    # 分析历史数据\n    history_desc, history_avg\
+          \ = analyze_history(past_24h)\n    \n    # 获取15分钟内的数据点并排序\n    recent_values\
           \ = []\n    for ts in recent_15m['result']['timeseries']:\n        for timestamp,\
           \ value in ts['chart']['chartData'].items():\n            recent_values.append((int(timestamp),\
-          \ float(value)))\n    \n    recent_values.sort()\n    recent_max = max(v\
-          \ for _, v in recent_values) if recent_values else 0\n    last_few = [v\
-          \ for _, v in recent_values[-3:]] if len(recent_values) >= 3 else [v for\
-          \ _, v in recent_values]\n    \n    # 判断告警有效性\n    vaild = \"true\"\n  \
-          \  alert_desc = []\n    if recent_max > history_max * 2:  # 峰值远超历史\n   \
-          \     alert_desc.append(\n            f\"当前15分钟内出现的{recent_max:.3f}峰值远高于历史平均({history_max:.3f})\"\
+          \ float(value)))\n    \n    recent_values.sort()\n    if not recent_values:\n\
+          \        return {\n            \"abnormal\": \"true\",\n            \"conclusion\"\
+          : \"\\n\".join([\n                \"MetricsData趋势分析\",\n               \
+          \ \"当前15分钟数据趋势：\",\n                \"  无数据可用\",\n                \"历史数据对比：\"\
+          ,\n                *[f\"  {line}\" for line in history_desc],\n        \
+          \        \"告警有效性判断：\",\n                \"  无最近数据，告警无效\",\n            \
+          \    \"结论：告警无效\"\n            ]) + \"\\n\"\n        }\n    \n    # 计算加权平均值（越靠近当前时间点权重越高）\n\
+          \    weights = [1 + i * 0.1 for i in range(len(recent_values))]  # 线性递增权重\n\
+          \    weighted_sum = sum(v * w for (_, v), w in zip(recent_values, weights))\n\
+          \    weight_total = sum(weights)\n    weighted_avg = weighted_sum / weight_total\
+          \ if weight_total > 0 else 0\n    \n    # 判断趋势：波动还是升高\n    trend_type =\
+          \ \"波动\"\n    if weighted_avg > history_avg * 1.2:\n        trend_type =\
+          \ \"升高\"\n    \n    # 获取最后几个点和最大值\n    recent_max = max(v for _, v in recent_values)\n\
+          \    last_value = recent_values[-1][1] if recent_values else 0\n    \n \
+          \   # 判断告警有效性\n    valid = \"true\"\n    alert_desc = []\n    \n    # 如果最后一个点显著升高（>\
+          \ 历史平均值的1.2倍），告警有效\n    if last_value > history_avg * 1.2:\n        alert_desc.append(\n\
+          \            f\"最后一个数据点({timestamp_to_readable(recent_values[-1][0])}: {last_value:.3f})\"\
+          \n            f\"显著高于历史平均值({history_avg:.3f})\"\n        )\n        alert_desc.append(\"\
+          指标在最近时间点出现升高，表明潜在异常\")\n        alert_conclusion = \"告警有效\"\n        valid\
+          \ = \"false\"\n    elif recent_max > history_avg * 1.2:\n        alert_desc.append(\n\
+          \            f\"当前15分钟内最大值({recent_max:.3f})高于历史平均值({history_avg:.3f})\"\
           \n        )\n        peak_duration = sum(1 for _, v in recent_values if\
-          \ v > history_max * 2) * 0.5  # 假设每点3分钟\n        alert_desc.append(f\"虽然指标在短时间内(约{peak_duration}分钟)出现了远高于历史水平的峰值，但：\"\
-          )\n        alert_desc.append(f\"峰值持续时间很短(约{peak_duration}分钟)\")\n      \
-          \  \n        if all(v < 0.01 for v in last_few):\n            alert_desc.append(\"\
-          随后指标迅速回落到正常水平(0附近)\")\n            alert_desc.append(\"当前时刻指标已恢复正常\")\n\
-          \            alert_conclusion = \"告警无效\"\n        else:\n            alert_desc.append(\"\
-          指标未完全恢复正常\")\n            alert_conclusion = \"告警有效\"\n            vaild\
-          \ = \"false\"\n    else:\n        alert_desc.append(\"当前15分钟内无显著异常峰值\")\n\
-          \        alert_conclusion = \"告警无效\"\n    \n    # 组合报告\n    report = [\n\
-          \        \"MetricsData趋势分析\",\n        \"当前15分钟数据趋势：\"\n    ] + [f\"  {line}\"\
-          \ for line in trend_desc] + [\n        \"历史数据对比：\"\n    ] + [f\"  {line}\"\
-          \ for line in history_desc] + [\n        \"告警有效性判断：\"\n    ] + [f\"  {line}\"\
-          \ for line in alert_desc] + [\n        f\"结论：{alert_conclusion}\"\n    ]\n\
-          \    \n    return {\n        \"abnormal\": str(vaild),\n        \"conclusion\"\
-          : \"\\n\".join(report)+\"\\n\",\n    }\n\ndef main(service: str, endpoint:\
-          \ str, start: int, end: int) -> dict:\n    current = get_service_latency(start,\
-          \ end, service, endpoint)\n\n    hour = 3600 * 1000000\n    history = get_service_latency(\n\
-          \        start - hour,\n        start,\n        service,\n        endpoint,\n\
-          \    )\n    res = analyze_latency(history, current)\n    return res\n"
+          \ v > history_avg * 1.2) * 0.5  # 假设每点0.5分钟\n        alert_desc.append(f\"\
+          峰值持续时间约{peak_duration}分钟\")\n        if trend_type == \"升高\":\n        \
+          \    alert_desc.append(\"指标呈现升高趋势，表明潜在异常\")\n            alert_conclusion\
+          \ = \"告警有效\"\n            valid = \"false\"\n        else:\n           \
+          \ alert_desc.append(\"指标呈现波动趋势，未持续升高\")\n            alert_desc.append(\"\
+          指标已回落，告警无效\")\n            alert_conclusion = \"告警无效\"\n    else:\n    \
+          \    alert_desc.append(\"当前15分钟内无显著异常峰值\")\n        alert_desc.append(f\"\
+          指标呈现{trend_type}趋势，告警无效\")\n        alert_conclusion = \"告警无效\"\n    \n\
+          \    # 组合报告\n    report = [\n        \"MetricsData趋势分析\",\n        \"当前15分钟数据趋势：\"\
+          ,\n        *[f\"  {line}\" for line in trend_desc],\n        f\"  趋势类型：{trend_type}\
+          \ (加权平均值: {weighted_avg:.6f})\",\n        \"\\n历史数据对比：\",\n        *[f\"\
+          \  {line}\" for line in history_desc],\n        \"\\n告警有效性判断：\",\n     \
+          \   *[f\"  {line}\" for line in alert_desc],\n        f\"结论：{alert_conclusion}\"\
+          \n    ]\n    \n    return {\n        \"abnormal\": str(valid),\n       \
+          \ \"conclusion\": \"\\n\".join(report) + \"\\n\"\n    }\n\ndef main(service:\
+          \ str, endpoint: str, start: int, end: int) -> dict:\n    current = get_service_latency(start,\
+          \ end, service, endpoint)\n\n    hour = 3600 * 1000000\n    day = 24 * hour\n\
+          \    history = get_service_latency(\n        start - day,\n        start,\n\
+          \        service,\n        endpoint,\n    )\n    res = analyze_latency(history,\
+          \ current)\n    return res"
         code_language: python3
         desc: ''
         outputs:
@@ -6455,11 +6502,11 @@ workflow:
       height: 54
       id: '1744599772545'
       position:
-        x: 2462
-        y: 3246.5
+        x: 2446
+        y: 3108
       positionAbsolute:
-        x: 2462
-        y: 3246.5
+        x: 2446
+        y: 3108
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6469,7 +6516,7 @@ workflow:
         cases:
         - case_id: 'true'
           conditions:
-          - comparison_operator: contains
+          - comparison_operator: empty
             id: 386bdf86-7414-490d-9106-cd665b9bf6da
             value: 'false'
             varType: string
@@ -6485,11 +6532,11 @@ workflow:
       height: 126
       id: '1744599891369'
       position:
-        x: 2766
-        y: 3210.5
+        x: 2726.602595388348
+        y: 3072
       positionAbsolute:
-        x: 2766
-        y: 3210.5
+        x: 2726.602595388348
+        y: 3072
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6512,11 +6559,11 @@ workflow:
       height: 116
       id: '1744599930141'
       position:
-        x: 3070
-        y: 3177
+        x: 3033.089109302272
+        y: 3197.8670859508925
       positionAbsolute:
-        x: 3070
-        y: 3177
+        x: 3033.089109302272
+        y: 3197.8670859508925
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6533,14 +6580,14 @@ workflow:
           - conclusion
         - - '1744339618961'
           - conclusion
-      height: 131
+      height: 130
       id: '1744627472534'
       position:
-        x: 3374
-        y: 3083.5
+        x: 3412.4162012564284
+        y: 3112.6849392061613
       positionAbsolute:
-        x: 3374
-        y: 3083.5
+        x: 3412.4162012564284
+        y: 3112.6849392061613
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6712,11 +6759,11 @@ workflow:
       height: 54
       id: '1748272742118'
       position:
-        x: 1854
-        y: 2805
+        x: 1842
+        y: 2684
       positionAbsolute:
-        x: 1854
-        y: 2805
+        x: 1842
+        y: 2684
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6888,11 +6935,11 @@ workflow:
       height: 54
       id: '17482728139340'
       position:
-        x: 2158
-        y: 2805
+        x: 2144
+        y: 2684
       positionAbsolute:
-        x: 2158
-        y: 2805
+        x: 2144
+        y: 2684
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6908,11 +6955,11 @@ workflow:
       height: 54
       id: '1748340985944'
       position:
-        x: 1854
-        y: 3177
+        x: 1842
+        y: 2834
       positionAbsolute:
-        x: 1854
-        y: 3177
+        x: 1842
+        y: 2834
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6931,11 +6978,11 @@ workflow:
       height: 90
       id: '1748341014888'
       position:
-        x: 2158
-        y: 3159
+        x: 2144
+        y: 2816
       positionAbsolute:
-        x: 2158
-        y: 3159
+        x: 2144
+        y: 2816
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6977,11 +7024,11 @@ workflow:
       height: 54
       id: '1750057744917'
       position:
-        x: 942
-        y: 638
+        x: 936
+        y: 637
       positionAbsolute:
-        x: 942
-        y: 638
+        x: 936
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7007,11 +7054,11 @@ workflow:
       height: 126
       id: '1750057811167'
       position:
-        x: 1246
-        y: 638
+        x: 1238
+        y: 637
       positionAbsolute:
-        x: 1246
-        y: 638
+        x: 1238
+        y: 637
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7213,17 +7260,185 @@ workflow:
       height: 894
       id: '1750058827536'
       position:
-        x: 1550
-        y: 1554
+        x: 1540
+        y: 1551
       positionAbsolute:
-        x: 1550
-        y: 1554
+        x: 1540
+        y: 1551
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
+    - data:
+        desc: ''
+        output_type: string
+        selected: false
+        title: 大模型结论
+        type: variable-aggregator
+        variables:
+        - - '1742366141890'
+          - text
+        - - '1750745788772'
+          - text
+        - - '1751515586426'
+          - text
+      height: 152
+      id: '1750745724225'
+      position:
+        x: 3352
+        y: 2040
+      positionAbsolute:
+        x: 3352
+        y: 2040
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 1f3e1690-58bf-4bc0-be08-4fab41ac13cf
+          role: system
+          text: 你是一个智能助手,帮助用户解决可观测性领域的问题
+        - id: 3e428a13-6852-444a-b572-816041c6a9f4
+          role: user
+          text: '##目的
+
+            请分析系统/应用过去15分钟内的请求成功率指标变化趋势，并结合当前的告警事件进行分析。
+
+            ##步骤
+
+            1. 列出过去15分钟内MetricsData的变化趋势，描述这些Metrics的变化是否正常，是否有异常的波动或趋势。
+
+            2. 告警有效性确认：结合告警事件，判断当前告警是否有效。
+
+            请求成功率在最近15分钟内如果一直下降，则认为有效
+
+            时间点越靠后的数据，如果成功率没有恢复，认为有效
+
+            如果最后恢复，认为无效
+
+            ##输出
+
+            描述MetricsData趋势，并得出告警是否有效的结论。
+
+            注意：告警有效性分析的结论只能是有效或无效
+
+            ##Data
+
+            MetricsData
+
+            {{#1741329632798.text#}}
+
+            metricsdata的历史数据
+
+            {{#17424344697090.text#}}
+
+            警报事件描述
+
+            {{#1741157526222.alert#}}'
+        selected: false
+        title: 请求成功率判断
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750745788772'
+      position:
+        x: 3050
+        y: 2740
+      positionAbsolute:
+        x: 3050
+        y: 2740
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 6b23adfe-47ca-40af-aeb1-ce2f1533826a
+          role: system
+          text: 你是一个智能助手,帮助用户解决可观测性领域的问题
+        - id: 1daa3763-312d-4ba2-91bb-5353e6387a0d
+          role: user
+          text: '##目的
+
+            请分析系统/应用过去15分钟内的请求成功率指标变化趋势，并结合当前的告警事件进行分析。
+
+            ##步骤
+
+            1. 列出过去15分钟内MetricsData的变化趋势，描述这些Metrics的变化是否正常，是否有异常的波动或趋势。
+
+            2. 告警有效性确认：结合告警事件，判断当前告警是否有效。
+
+            请求成功率在最近15分钟内如果一直下降，则认为有效
+
+            时间点越靠后的数据，如果成功率没有恢复，认为有效
+
+            如果最后恢复，认为无效
+
+            ##输出
+
+            如果指标持续超过0.05s甚至到达0.2s，认为该告警有效
+
+            如果抖动，少数点位发生波动，没有持续升高，认为无效
+
+            描述MetricsData趋势，并得出告警是否有效的结论。
+
+            注意：告警有效性分析的结论只能是有效或无效
+
+            ##Data
+
+            MetricsData
+
+            {{#1741328197695.text#}}
+
+            警报事件描述
+
+            {{#1741157526222.alert#}}'
+        selected: true
+        title: RTT指标
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1751515586426'
+      position:
+        x: 2994.2153979484565
+        y: 2505.498466761298
+      positionAbsolute:
+        x: 2994.2153979484565
+        y: 2505.498466761298
+      selected: true
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
     viewport:
-      x: 88.9588371254672
-      y: -93.15652831830675
-      zoom: 0.42278401763515033
+      x: 33.26069319412994
+      y: -366.90539261761455
+      zoom: 0.31261008358990805

--- a/api/init_data/workflows/zh/告警有效性确认.yml
+++ b/api/init_data/workflows/zh/告警有效性确认.yml
@@ -886,17 +886,6 @@ workflow:
         isInIteration: false
         sourceType: if-else
         targetType: tool
-      id: 1750058827536-75243699-b060-4295-b510-27cbc73b6be7-1741328045214-target
-      source: '1750058827536'
-      sourceHandle: 75243699-b060-4295-b510-27cbc73b6be7
-      target: '1741328045214'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: if-else
-        targetType: tool
       id: 1750058827536-681cae12-3dcd-439a-9ad7-d164e8062cf3-1742979394268-target
       source: '1750058827536'
       sourceHandle: 681cae12-3dcd-439a-9ad7-d164e8062cf3
@@ -1146,6 +1135,61 @@ workflow:
       targetHandle: target
       type: custom
       zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: if-else
+      id: 1750058827536-75243699-b060-4295-b510-27cbc73b6be7-1751618293412-target
+      source: '1750058827536'
+      sourceHandle: 75243699-b060-4295-b510-27cbc73b6be7
+      target: '1751618293412'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1751618293412-false-1741328045214-target
+      source: '1751618293412'
+      sourceHandle: 'false'
+      target: '1741328045214'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1751618293412-true-17516184500710-target
+      source: '1751618293412'
+      sourceHandle: 'true'
+      target: '17516184500710'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 17516184500710-source-1751618472852-target
+      source: '17516184500710'
+      sourceHandle: source
+      target: '1751618472852'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: variable-aggregator
+      id: 1751618472852-source-1750745724225-target
+      source: '1751618472852'
+      sourceHandle: source
+      target: '1750745724225'
+      targetHandle: target
+      type: custom
+      zIndex: 0
     nodes:
     - data:
         desc: ''
@@ -1329,7 +1373,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1741157526222'
@@ -1340,7 +1384,7 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 882
+      height: 876
       id: '1741158559444'
       position:
         x: 1540
@@ -1564,11 +1608,11 @@ workflow:
       height: 54
       id: '1741328045214'
       position:
-        x: 1842
-        y: 3108
+        x: 2133.618409250169
+        y: 3081.4582959588693
       positionAbsolute:
-        x: 1842
-        y: 3108
+        x: 2133.618409250169
+        y: 3081.4582959588693
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2846,7 +2890,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: c981a70d-9ebb-4f03-949a-8d78826f9bda
@@ -2899,7 +2943,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1742366141890'
       position:
         x: 3050
@@ -2935,7 +2979,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1742366141890'
@@ -2946,7 +2990,7 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 174
+      height: 168
       id: '1742366303110'
       position:
         x: 3654
@@ -2992,11 +3036,11 @@ workflow:
       height: 80
       id: '1742433446760'
       position:
-        x: 634
-        y: 637
+        x: 620.0306820836154
+        y: 630.0153410418077
       positionAbsolute:
-        x: 634
-        y: 637
+        x: 620.0306820836154
+        y: 630.0153410418077
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3137,10 +3181,10 @@ workflow:
       height: 54
       id: '17424339242280'
       position:
-        x: 2144
+        x: 2444
         y: 3108
       positionAbsolute:
-        x: 2144
+        x: 2444
         y: 3108
       selected: false
       sourcePosition: right
@@ -6035,7 +6079,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: a1de005a-fbe2-44a6-9b2c-bb021ae6b3a4
@@ -6064,7 +6108,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1744093428286'
       position:
         x: 2144
@@ -6318,10 +6362,10 @@ workflow:
       height: 54
       id: '1744339618961'
       position:
-        x: 3146.917656182187
+        x: 3446.917656182187
         y: 2982.1617777841084
       positionAbsolute:
-        x: 3146.917656182187
+        x: 3446.917656182187
         y: 2982.1617777841084
       selected: false
       sourcePosition: right
@@ -6345,10 +6389,10 @@ workflow:
       height: 116
       id: '1744343454355'
       position:
-        x: 3701.829492661339
+        x: 4001.829492661339
         y: 3182.7384192889735
       positionAbsolute:
-        x: 3701.829492661339
+        x: 4001.829492661339
         y: 3182.7384192889735
       selected: false
       sourcePosition: right
@@ -6502,10 +6546,10 @@ workflow:
       height: 54
       id: '1744599772545'
       position:
-        x: 2446
+        x: 2746
         y: 3108
       positionAbsolute:
-        x: 2446
+        x: 2746
         y: 3108
       selected: false
       sourcePosition: right
@@ -6532,10 +6576,10 @@ workflow:
       height: 126
       id: '1744599891369'
       position:
-        x: 2726.602595388348
+        x: 3026.602595388348
         y: 3072
       positionAbsolute:
-        x: 2726.602595388348
+        x: 3026.602595388348
         y: 3072
       selected: false
       sourcePosition: right
@@ -6559,10 +6603,10 @@ workflow:
       height: 116
       id: '1744599930141'
       position:
-        x: 3033.089109302272
+        x: 3333.089109302272
         y: 3197.8670859508925
       positionAbsolute:
-        x: 3033.089109302272
+        x: 3333.089109302272
         y: 3197.8670859508925
       selected: false
       sourcePosition: right
@@ -6583,10 +6627,10 @@ workflow:
       height: 130
       id: '1744627472534'
       position:
-        x: 3412.4162012564284
+        x: 3712.4162012564284
         y: 3112.6849392061613
       positionAbsolute:
-        x: 3412.4162012564284
+        x: 3712.4162012564284
         y: 3112.6849392061613
       selected: false
       sourcePosition: right
@@ -7024,10 +7068,10 @@ workflow:
       height: 54
       id: '1750057744917'
       position:
-        x: 936
+        x: 934.6030682083615
         y: 637
       positionAbsolute:
-        x: 936
+        x: 934.6030682083615
         y: 637
       selected: false
       sourcePosition: right
@@ -7260,11 +7304,11 @@ workflow:
       height: 894
       id: '1750058827536'
       position:
-        x: 1540
-        y: 1551
+        x: 1362.589662461914
+        y: 1548.206136416723
       positionAbsolute:
-        x: 1540
-        y: 1551
+        x: 1362.589662461914
+        y: 1548.206136416723
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7273,7 +7317,7 @@ workflow:
     - data:
         desc: ''
         output_type: string
-        selected: false
+        selected: true
         title: 大模型结论
         type: variable-aggregator
         variables:
@@ -7283,7 +7327,9 @@ workflow:
           - text
         - - '1751515586426'
           - text
-      height: 152
+        - - '1751618472852'
+          - text
+      height: 174
       id: '1750745724225'
       position:
         x: 3352
@@ -7291,7 +7337,7 @@ workflow:
       positionAbsolute:
         x: 3352
         y: 2040
-      selected: false
+      selected: true
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -7305,7 +7351,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 1f3e1690-58bf-4bc0-be08-4fab41ac13cf
@@ -7354,7 +7400,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1750745788772'
       position:
         x: 3050
@@ -7376,7 +7422,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 6b23adfe-47ca-40af-aeb1-ce2f1533826a
@@ -7419,13 +7465,13 @@ workflow:
             警报事件描述
 
             {{#1741157526222.alert#}}'
-        selected: true
+        selected: false
         title: RTT指标
         type: llm
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1751515586426'
       position:
         x: 2994.2153979484565
@@ -7433,12 +7479,254 @@ workflow:
       positionAbsolute:
         x: 2994.2153979484565
         y: 2505.498466761298
-      selected: true
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        cases:
+        - case_id: 'true'
+          conditions:
+          - comparison_operator: contains
+            id: e9cd649c-4165-4f38-8196-35db38d06c81
+            value: 平均请求延时超过
+            varType: string
+            variable_selector:
+            - '1741157526222'
+            - alert
+          id: 'true'
+          logical_operator: and
+        desc: ''
+        selected: false
+        title: 条件分支 4
+        type: if-else
+      height: 126
+      id: '1751618293412'
+      position:
+        x: 1751.1994335434993
+        y: 3126.1601132913006
+      positionAbsolute:
+        x: 1751.1994335434993
+        y: 3126.1601132913006
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Specified service name
+            ja_JP: Specified service name
+            pt_BR: Specified service name
+            zh_Hans: 指定的服务名
+          label:
+            en_US: service_name
+            ja_JP: service_name
+            pt_BR: service_name
+            zh_Hans: service_name
+          llm_description: 指定的服务名
+          max: null
+          min: null
+          name: service_name
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Specified endpoint name
+            ja_JP: Specified endpoint name
+            pt_BR: Specified endpoint name
+            zh_Hans: 指定的服务端点名
+          label:
+            en_US: content_key
+            ja_JP: content_key
+            pt_BR: content_key
+            zh_Hans: content_key
+          llm_description: 指定的服务端点名
+          max: null
+          min: null
+          name: content_key
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time
+            ja_JP: Data query start time
+            pt_BR: Data query start time
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time
+            ja_JP: Data query end time
+            pt_BR: Data query end time
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query start time
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          content_key: ''
+          endTime: ''
+          service_name: ''
+          startTime: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 服务平均响应时间(毫秒,按服务名和内容键统计,指定时间段内) (1)
+        tool_configurations: {}
+        tool_label: 服务平均响应时间(毫秒,按服务名和内容键统计,指定时间段内)
+        tool_name: Originx 北极星指标 (服务层级) - RED指标 - 平均响应时间
+        tool_parameters:
+          content_key:
+            type: mixed
+            value: '{{#1742806924635.endpoint#}}'
+          endTime:
+            type: variable
+            value:
+            - '1741157526222'
+            - endTime
+          service_name:
+            type: mixed
+            value: '{{#1742806924635.service#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741157526222'
+            - startTime
+        type: tool
+      height: 54
+      id: '17516184500710'
+      position:
+        x: 2123.7432588394763
+        y: 3182.7384192889735
+      positionAbsolute:
+        x: 2123.7432588394763
+        y: 3182.7384192889735
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: deepseek-chat
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 3b4e8314-ba43-40a5-aaab-bb1af4f4af70
+          role: system
+          text: 你是一个可观测性领域智能助手
+        - id: c21bf2be-ebce-48e9-9c29-a2adbf288f27
+          role: user
+          text: '##目的
+
+            请分析系统/应用过去15分钟内的请求成功率指标变化趋势，并结合当前的告警事件进行分析。
+
+            ##步骤
+
+            1. 列出过去15分钟内MetricsData的变化趋势，描述这些Metrics的变化是否正常，是否有异常的波动或趋势。
+
+            2. 告警有效性确认：结合告警事件，判断当前告警是否有效。
+
+            请求成功率在最近15分钟内如果一直下降，则认为有效
+
+            时间点越靠后的数据，如果成功率没有恢复，认为有效
+
+            如果最后恢复，认为无效
+
+            ##输出
+
+            描述MetricsData趋势，并得出告警是否有效的结论。
+
+            注意：告警有效性分析的结论只能是有效或无效
+
+            ##Data
+
+            MetricsData
+
+            {{#17516184500710.text#}}
+
+            警报事件描述
+
+            {{#1741157526222.alert#}}'
+        selected: false
+        title: 响应时间判断
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 90
+      id: '1751618472852'
+      position:
+        x: 2564.3303395300104
+        y: 3243.626635982344
+      positionAbsolute:
+        x: 2564.3303395300104
+        y: 3243.626635982344
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
     viewport:
-      x: 33.26069319412994
-      y: -366.90539261761455
-      zoom: 0.31261008358990805
+      x: -1065.9079752839043
+      y: -1384.4337287275648
+      zoom: 0.6076709420860494

--- a/api/init_data/workflows/zh/告警简单根因分析.yml
+++ b/api/init_data/workflows/zh/告警简单根因分析.yml
@@ -9,7 +9,7 @@ dependencies:
 - current_identifier: null
   type: package
   value:
-    plugin_unique_identifier: langgenius/deepseek:0.0.5@fd6efd37c2a931911de8ab9ca3ba2da303bef146d45ee87ad896b04b36d09403
+    plugin_unique_identifier: langgenius/openai_api_compatible:0.0.7@f20c7275bbcf055ec5d170dd5128e341986e2dcba5266d08fd080d4bdf2288f6
 kind: app
 version: 0.1.5
 workflow:
@@ -87,18 +87,6 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: llm
-        targetType: end
-      id: 1741512806512-source-1741502839759-target
-      selected: false
-      source: '1741512806512'
-      sourceHandle: source
-      target: '1741502839759'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: template-transform
         targetType: end
       id: 1741592094819-source-1741592144815-target
@@ -123,30 +111,6 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: tool
-        targetType: variable-aggregator
-      id: 1741597223833-source-1741597274153-target
-      selected: false
-      source: '1741597223833'
-      sourceHandle: source
-      target: '1741597274153'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: code
-        targetType: variable-aggregator
-      id: 1741599658821-source-1741597274153-target
-      selected: false
-      source: '1741599658821'
-      sourceHandle: source
-      target: '1741597274153'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: if-else
         targetType: template-transform
       id: 1742453019576-false-1741592094819-target
@@ -154,54 +118,6 @@ workflow:
       source: '1742453019576'
       sourceHandle: 'false'
       target: '1741592094819'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: if-else
-        targetType: code
-      id: 1742453019576-true-1741599658821-target
-      selected: false
-      source: '1742453019576'
-      sourceHandle: 'true'
-      target: '1741599658821'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: if-else
-        targetType: tool
-      id: 1742453019576-2949ad86-bdc0-4b1d-bd84-6e01f41915eb-1741597223833-target
-      selected: false
-      source: '1742453019576'
-      sourceHandle: 2949ad86-bdc0-4b1d-bd84-6e01f41915eb
-      target: '1741597223833'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: if-else
-        targetType: tool
-      id: 1742453019576-74dc1f70-729f-47e1-a6c8-9f0a1d2a6ad9-1742629595400-target
-      selected: false
-      source: '1742453019576'
-      sourceHandle: 74dc1f70-729f-47e1-a6c8-9f0a1d2a6ad9
-      target: '1742629595400'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: variable-aggregator
-      id: 1742629595400-source-1741597274153-target
-      selected: false
-      source: '1742629595400'
-      sourceHandle: source
-      target: '1741597274153'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -279,18 +195,6 @@ workflow:
       source: '17430595109950'
       sourceHandle: source
       target: '17430595158080'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: tool
-      id: 17430597987060-source-17430598152780-target
-      selected: false
-      source: '17430597987060'
-      sourceHandle: source
-      target: '17430598152780'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -607,131 +511,12 @@ workflow:
       type: custom
       zIndex: 0
     - data:
-        isInIteration: false
-        sourceType: code
-        targetType: tool
-      id: 1744255998058-source-1745323059455-target
-      selected: false
-      source: '1744255998058'
-      sourceHandle: source
-      target: '1745323059455'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: code
-      id: 1745323059455-source-1744287265980-target
-      selected: false
-      source: '1745323059455'
-      sourceHandle: source
-      target: '1744287265980'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: code
-      id: 1745323078946-source-17443356883380-target
-      selected: false
-      source: '1745323078946'
-      sourceHandle: source
-      target: '17443356883380'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: tool
-      id: 17430610756270-source-1745323078946-target
-      selected: false
-      source: '17430610756270'
-      sourceHandle: source
-      target: '1745323078946'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: tool
-      id: 17430595158080-source-1745323114690-target
-      selected: false
-      source: '17430595158080'
-      sourceHandle: source
-      target: '1745323114690'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: code
-      id: 1745323114690-source-17443357899060-target
-      selected: false
-      source: '1745323114690'
-      sourceHandle: source
-      target: '17443357899060'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: tool
-      id: 17430598152780-source-1745323119371-target
-      selected: false
-      source: '17430598152780'
-      sourceHandle: source
-      target: '1745323119371'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: code
-      id: 1745323119371-source-17443357893440-target
-      selected: false
-      source: '1745323119371'
-      sourceHandle: source
-      target: '17443357893440'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: code
-        targetType: tool
-      id: 17442560822670-source-1745323124559-target
-      selected: false
-      source: '17442560822670'
-      sourceHandle: source
-      target: '1745323124559'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: code
-      id: 1745323124559-source-17443357536900-target
-      selected: false
-      source: '1745323124559'
-      sourceHandle: source
-      target: '17443357536900'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
         isInIteration: true
         iteration_id: '1741497176064'
         sourceType: tool
         targetType: tool
       id: 1742980228913-source-1745325937486-target
+      selected: false
       source: '1742980228913'
       sourceHandle: source
       target: '1745325937486'
@@ -744,6 +529,7 @@ workflow:
         sourceType: tool
         targetType: code
       id: 1745325937486-source-1744342244843-target
+      selected: false
       source: '1745325937486'
       sourceHandle: source
       target: '1744342244843'
@@ -756,6 +542,7 @@ workflow:
         sourceType: tool
         targetType: tool
       id: 1742980318484-source-1745326017289-target
+      selected: false
       source: '1742980318484'
       sourceHandle: source
       target: '1745326017289'
@@ -768,6 +555,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1744342138380-source-1745326029444-target
+      selected: false
       source: '1744342138380'
       sourceHandle: source
       target: '1745326029444'
@@ -780,6 +568,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1744342068305-source-1745326038950-target
+      selected: false
       source: '1744342068305'
       sourceHandle: source
       target: '1745326038950'
@@ -792,6 +581,7 @@ workflow:
         sourceType: tool
         targetType: tool
       id: 1741502699500-source-1745326055068-target
+      selected: false
       source: '1741502699500'
       sourceHandle: source
       target: '1745326055068'
@@ -804,6 +594,7 @@ workflow:
         sourceType: tool
         targetType: code
       id: 1745326017289-source-1744342309386-target
+      selected: false
       source: '1745326017289'
       sourceHandle: source
       target: '1744342309386'
@@ -816,6 +607,7 @@ workflow:
         sourceType: tool
         targetType: code
       id: 1745326029444-source-1744342372882-target
+      selected: false
       source: '1745326029444'
       sourceHandle: source
       target: '1744342372882'
@@ -828,6 +620,7 @@ workflow:
         sourceType: tool
         targetType: code
       id: 1745326038950-source-1744342426374-target
+      selected: false
       source: '1745326038950'
       sourceHandle: source
       target: '1744342426374'
@@ -840,6 +633,7 @@ workflow:
         sourceType: tool
         targetType: code
       id: 1745326055068-source-1744342478278-target
+      selected: false
       source: '1745326055068'
       sourceHandle: source
       target: '1744342478278'
@@ -851,6 +645,7 @@ workflow:
         sourceType: llm
         targetType: iteration
       id: 17430596469370-source-1741497176064-target
+      selected: false
       source: '17430596469370'
       sourceHandle: source
       target: '1741497176064'
@@ -863,6 +658,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1741497181784-source-1742980720651-target
+      selected: false
       source: '1741497181784'
       sourceHandle: source
       target: '1742980720651'
@@ -875,6 +671,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1741497181784-source-1742980748320-target
+      selected: false
       source: '1741497181784'
       sourceHandle: source
       target: '1742980748320'
@@ -887,6 +684,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1741497181784-source-1742980780865-target
+      selected: false
       source: '1741497181784'
       sourceHandle: source
       target: '1742980780865'
@@ -899,6 +697,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1741497181784-source-1742980837261-target
+      selected: false
       source: '1741497181784'
       sourceHandle: source
       target: '1742980837261'
@@ -911,6 +710,7 @@ workflow:
         sourceType: code
         targetType: tool
       id: 1741497181784-source-1742980885557-target
+      selected: false
       source: '1741497181784'
       sourceHandle: source
       target: '1742980885557'
@@ -919,75 +719,10 @@ workflow:
       zIndex: 1002
     - data:
         isInIteration: false
-        sourceType: code
-        targetType: tool
-      id: 17443388433580-source-1745388058502-target
-      source: '17443388433580'
-      sourceHandle: source
-      target: '1745388058502'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: llm
-      id: 1745388058502-source-17430596469370-target
-      source: '1745388058502'
-      sourceHandle: source
-      target: '17430596469370'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: code
-        targetType: tool
-      id: 17443388438160-source-17453881280910-target
-      source: '17443388438160'
-      sourceHandle: source
-      target: '17453881280910'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: llm
-      id: 17453881280910-source-17430596469370-target
-      source: '17453881280910'
-      sourceHandle: source
-      target: '17430596469370'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: code
-        targetType: tool
-      id: 17443388443000-source-17453881639600-target
-      source: '17443388443000'
-      sourceHandle: source
-      target: '17453881639600'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: llm
-      id: 17453881639600-source-17430596469370-target
-      source: '17453881639600'
-      sourceHandle: source
-      target: '17430596469370'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: start
         targetType: code
       id: 1741227526517-source-1742807803325-target
+      selected: false
       source: '1741227526517'
       sourceHandle: source
       target: '1742807803325'
@@ -999,6 +734,7 @@ workflow:
         sourceType: code
         targetType: if-else
       id: 1741509454645-source-1745494305165-target
+      selected: false
       source: '1741509454645'
       sourceHandle: source
       target: '1745494305165'
@@ -1010,6 +746,7 @@ workflow:
         sourceType: if-else
         targetType: code
       id: 1745494305165-true-17430589567120-target
+      selected: false
       source: '1745494305165'
       sourceHandle: 'true'
       target: '17430589567120'
@@ -1021,6 +758,7 @@ workflow:
         sourceType: if-else
         targetType: template-transform
       id: 1745494305165-false-1745494335273-target
+      selected: false
       source: '1745494305165'
       sourceHandle: 'false'
       target: '1745494335273'
@@ -1032,6 +770,7 @@ workflow:
         sourceType: template-transform
         targetType: end
       id: 1745494335273-source-1745494338512-target
+      selected: false
       source: '1745494335273'
       sourceHandle: source
       target: '1745494338512'
@@ -1055,6 +794,7 @@ workflow:
         sourceType: code
         targetType: if-else
       id: 17430589567120-source-1747355869184-target
+      selected: false
       source: '17430589567120'
       sourceHandle: source
       target: '1747355869184'
@@ -1066,6 +806,7 @@ workflow:
         sourceType: if-else
         targetType: tool
       id: 1747355869184-false-17430598907140-target
+      selected: false
       source: '1747355869184'
       sourceHandle: 'false'
       target: '17430598907140'
@@ -1077,6 +818,7 @@ workflow:
         sourceType: if-else
         targetType: tool
       id: 1747355869184-false-17430595109950-target
+      selected: false
       source: '1747355869184'
       sourceHandle: 'false'
       target: '17430595109950'
@@ -1088,6 +830,7 @@ workflow:
         sourceType: if-else
         targetType: tool
       id: 1747355869184-false-17430610719970-target
+      selected: false
       source: '1747355869184'
       sourceHandle: 'false'
       target: '17430610719970'
@@ -1099,6 +842,7 @@ workflow:
         sourceType: if-else
         targetType: tool
       id: 1747355869184-false-17430610599980-target
+      selected: false
       source: '1747355869184'
       sourceHandle: 'false'
       target: '17430610599980'
@@ -1107,32 +851,10 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: if-else
-        targetType: tool
-      id: 1747355869184-true-17473562733380-target
-      selected: false
-      source: '1747355869184'
-      sourceHandle: 'true'
-      target: '17473562733380'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: tool
-        targetType: tool
-      id: 17473562733380-source-17473564454180-target
-      source: '17473562733380'
-      sourceHandle: source
-      target: '17473564454180'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: tool
         targetType: tool
       id: 1747355986489-source-17473564423850-target
+      selected: false
       source: '1747355986489'
       sourceHandle: source
       target: '17473564423850'
@@ -1144,6 +866,7 @@ workflow:
         sourceType: if-else
         targetType: tool
       id: 1747355869184-false-17430597987060-target
+      selected: false
       source: '1747355869184'
       sourceHandle: 'false'
       target: '17430597987060'
@@ -1155,6 +878,7 @@ workflow:
         sourceType: tool
         targetType: code
       id: 17473564423850-source-1747356893645-target
+      selected: false
       source: '17473564423850'
       sourceHandle: source
       target: '1747356893645'
@@ -1163,20 +887,10 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: tool
-        targetType: code
-      id: 17473564454180-source-1747356923703-target
-      source: '17473564454180'
-      sourceHandle: source
-      target: '1747356923703'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: code
         targetType: llm
       id: 1747356893645-source-17473569800940-target
+      selected: false
       source: '1747356893645'
       sourceHandle: source
       target: '17473569800940'
@@ -1185,12 +899,13 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: code
+        sourceType: llm
         targetType: llm
-      id: 1747356923703-source-17473569800940-target
-      source: '1747356923703'
+      id: 17473569800940-source-17501667334220-target
+      selected: false
+      source: '17473569800940'
       sourceHandle: source
-      target: '17473569800940'
+      target: '17501667334220'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -1198,10 +913,668 @@ workflow:
         isInIteration: false
         sourceType: llm
         targetType: end
-      id: 17473569800940-source-1747357345949-target
-      source: '17473569800940'
+      id: 17501667334220-source-1747357345949-target
+      selected: false
+      source: '17501667334220'
       sourceHandle: source
       target: '1747357345949'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1742453019576-true-1750657927551-target
+      selected: false
+      source: '1742453019576'
+      sourceHandle: 'true'
+      target: '1750657927551'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1742453019576-2949ad86-bdc0-4b1d-bd84-6e01f41915eb-1750657927551-target
+      selected: false
+      source: '1742453019576'
+      sourceHandle: 2949ad86-bdc0-4b1d-bd84-6e01f41915eb
+      target: '1750657927551'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1742453019576-6b6a21b2-be07-4596-8e1b-031dd9ad9055-1750657927551-target
+      selected: false
+      source: '1742453019576'
+      sourceHandle: 6b6a21b2-be07-4596-8e1b-031dd9ad9055
+      target: '1750657927551'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1742453019576-0b3c7ecb-381d-4c8b-acd0-496085d91807-1750657965188-target
+      selected: false
+      source: '1742453019576'
+      sourceHandle: 0b3c7ecb-381d-4c8b-acd0-496085d91807
+      target: '1750657965188'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 1750657965188-source-1750658087300-target
+      selected: false
+      source: '1750657965188'
+      sourceHandle: source
+      target: '1750658087300'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: variable-aggregator
+      id: 1750658087300-source-1741597274153-target
+      selected: false
+      source: '1750658087300'
+      sourceHandle: source
+      target: '1741597274153'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 1750657927551-source-1750658174684-target
+      selected: false
+      source: '1750657927551'
+      sourceHandle: source
+      target: '1750658174684'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: variable-aggregator
+      id: 1750658174684-source-1741597274153-target
+      selected: false
+      source: '1750658174684'
+      sourceHandle: source
+      target: '1741597274153'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: tool
+      id: 17430597987060-source-1750661176423-target
+      source: '17430597987060'
+      sourceHandle: source
+      target: '1750661176423'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: llm
+      id: 1750662084996-source-1750662088384-target
+      source: '1750662084996'
+      sourceHandle: source
+      target: '1750662088384'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750662088384-source-1750661889002-target
+      source: '1750662088384'
+      sourceHandle: source
+      target: '1750661889002'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750068431868-source-1750672701216-target
+      source: '1750068431868'
+      sourceHandle: source
+      target: '1750672701216'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750662408086-source-17506728633540-target
+      source: '1750662408086'
+      sourceHandle: source
+      target: '17506728633540'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750661889002-source-1750754610625-target
+      source: '1750661889002'
+      sourceHandle: source
+      target: '1750754610625'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750662168285-source-1750754610625-target
+      source: '1750662168285'
+      sourceHandle: source
+      target: '1750754610625'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750672701216-source-1750754610625-target
+      source: '1750672701216'
+      sourceHandle: source
+      target: '1750754610625'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 17506728633540-source-1750754610625-target
+      source: '17506728633540'
+      sourceHandle: source
+      target: '1750754610625'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750750056742-source-1750754610625-target
+      source: '1750750056742'
+      sourceHandle: source
+      target: '1750754610625'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750769951427-source-1750754610625-target
+      source: '1750769951427'
+      sourceHandle: source
+      target: '1750754610625'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750830567613-source-1750830747193-target
+      source: '1750830567613'
+      sourceHandle: source
+      target: '1750830747193'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 1750830747193-source-1750830805330-target
+      source: '1750830747193'
+      sourceHandle: source
+      target: '1750830805330'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 1750830805330-source-1750819000832-target
+      source: '1750830805330'
+      sourceHandle: source
+      target: '1750819000832'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750927215923-source-1750769951427-target
+      source: '1750927215923'
+      sourceHandle: source
+      target: '1750769951427'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: llm
+      id: 1750830805330-source-1750927215923-target
+      source: '1750830805330'
+      sourceHandle: source
+      target: '1750927215923'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750927416010-source-1750769951427-target
+      source: '1750927416010'
+      sourceHandle: source
+      target: '1750769951427'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: llm
+      id: 1750819000832-source-1750927458985-target
+      source: '1750819000832'
+      sourceHandle: source
+      target: '1750927458985'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750927458985-source-1750769951427-target
+      source: '1750927458985'
+      sourceHandle: source
+      target: '1750769951427'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: llm
+      id: 1750830805330-source-1750927416010-target
+      source: '1750830805330'
+      sourceHandle: source
+      target: '1750927416010'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: end
+      id: 1750995139153-source-1741502839759-target
+      source: '1750995139153'
+      sourceHandle: source
+      target: '1741502839759'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 1750661176423-source-1751112705936-target
+      source: '1750661176423'
+      sourceHandle: source
+      target: '1751112705936'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 1751112705936-source-17443357893440-target
+      source: '1751112705936'
+      sourceHandle: source
+      target: '17443357893440'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 1744255998058-source-17511127594560-target
+      source: '1744255998058'
+      sourceHandle: source
+      target: '17511127594560'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 17511127594560-source-1744287265980-target
+      source: '17511127594560'
+      sourceHandle: source
+      target: '1744287265980'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 17430595158080-source-17511128355920-target
+      source: '17430595158080'
+      sourceHandle: source
+      target: '17511128355920'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 17511128355920-source-17443357899060-target
+      source: '17511128355920'
+      sourceHandle: source
+      target: '17443357899060'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 17442560822670-source-17511128736240-target
+      source: '17442560822670'
+      sourceHandle: source
+      target: '17511128736240'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 17511128736240-source-17443357536900-target
+      source: '17511128736240'
+      sourceHandle: source
+      target: '17443357536900'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 17430610756270-source-17511129103380-target
+      source: '17430610756270'
+      sourceHandle: source
+      target: '17511129103380'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: code
+      id: 17511129103380-source-17443356883380-target
+      source: '17511129103380'
+      sourceHandle: source
+      target: '17443356883380'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1747355869184-false-17473562733380-target
+      source: '1747355869184'
+      sourceHandle: 'false'
+      target: '17473562733380'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: llm
+      id: 17511674060740-source-17430596469370-target
+      source: '17511674060740'
+      sourceHandle: source
+      target: '17430596469370'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 17443388433580-source-1751504789699-target
+      source: '17443388433580'
+      sourceHandle: source
+      target: '1751504789699'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 1751504789699-source-17430596469370-target
+      source: '1751504789699'
+      sourceHandle: source
+      target: '17430596469370'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 17443388438160-source-17515048509810-target
+      source: '17443388438160'
+      sourceHandle: source
+      target: '17515048509810'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 17515048509810-source-17430596469370-target
+      source: '17515048509810'
+      sourceHandle: source
+      target: '17430596469370'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 17443388443000-source-17515048888700-target
+      source: '17443388443000'
+      sourceHandle: source
+      target: '17515048888700'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 17515048888700-source-17430596469370-target
+      source: '17515048888700'
+      sourceHandle: source
+      target: '17430596469370'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: code
+      id: 17473562733380-source-17515143872690-target
+      source: '17473562733380'
+      sourceHandle: source
+      target: '17515143872690'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: llm
+      id: 17515143872690-source-17511674060740-target
+      source: '17515143872690'
+      sourceHandle: source
+      target: '17511674060740'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 1751601681225-source-1750995139153-target
+      source: '1751601681225'
+      sourceHandle: source
+      target: '1750995139153'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: tool
+      id: 1750754610625-source-1751601681225-target
+      source: '1750754610625'
+      sourceHandle: source
+      target: '1751601681225'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: if-else
+      id: 1741512806512-source-1751601842740-target
+      source: '1741512806512'
+      sourceHandle: source
+      target: '1751601842740'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: code
+      id: 1751601842740-false-1750830567613-target
+      source: '1751601842740'
+      sourceHandle: 'false'
+      target: '1750830567613'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751601842740-false-1750662084996-target
+      source: '1751601842740'
+      sourceHandle: 'false'
+      target: '1750662084996'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751601842740-false-1750068431868-target
+      source: '1751601842740'
+      sourceHandle: 'false'
+      target: '1750068431868'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751601842740-false-1750662408086-target
+      source: '1751601842740'
+      sourceHandle: 'false'
+      target: '1750662408086'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: code
+      id: 1751601842740-false-1750750056742-target
+      source: '1751601842740'
+      sourceHandle: 'false'
+      target: '1750750056742'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: end
+      id: 1751601842740-true-1751601994805-target
+      source: '1751601842740'
+      sourceHandle: 'true'
+      target: '1751601994805'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: code
+      id: 1751601842740-false-1750662168285-target
+      source: '1751601842740'
+      sourceHandle: 'false'
+      target: '1750662168285'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -1242,14 +1615,20 @@ workflow:
           required: false
           type: text-input
           variable: nodeIp
-      height: 194
+        - label: edition
+          max_length: 48
+          options: []
+          required: false
+          type: paragraph
+          variable: edition
+      height: 220
       id: '1741227526517'
       position:
         x: 30
-        y: 359
+        y: 440
       positionAbsolute:
         x: 30
-        y: 359
+        y: 440
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1276,12 +1655,12 @@ workflow:
       height: 1408
       id: '1741497176064'
       position:
-        x: 5401
-        y: 1128
+        x: 5478
+        y: 904
       positionAbsolute:
-        x: 5401
-        y: 1128
-      selected: true
+        x: 5478
+        y: 904
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -1301,8 +1680,8 @@ workflow:
         x: 24
         y: 68
       positionAbsolute:
-        x: 5425
-        y: 1196
+        x: 5502
+        y: 972
       selectable: false
       selected: false
       sourcePosition: right
@@ -1311,9 +1690,9 @@ workflow:
       width: 44
       zIndex: 1002
     - data:
-        code: "\ndef main(arg1: str) -> dict:\n    data = json.loads(arg1)\n    return\
-          \ {\n        \"pod\": data.get(\"pod\", \"\"),\n        \"namespace\": data.get(\"\
-          namespace\", \"\"),\n        \"pid\": data.get(\"pid\", \"\")\n    }\n"
+        code: "\ndef main(data: dict) -> dict:\n    return {\n        \"pod\": data.get(\"\
+          pod\", \"\"),\n        \"namespace\": data.get(\"namespace\", \"\"),\n \
+          \       \"pid\": str(data.get(\"pid\", \"\"))\n    }\n"
         code_language: python3
         desc: ''
         isInIteration: true
@@ -1335,7 +1714,7 @@ workflow:
         - value_selector:
           - '1741497176064'
           - item
-          variable: arg1
+          variable: data
       height: 54
       id: '1741497181784'
       parentId: '1741497176064'
@@ -1343,8 +1722,8 @@ workflow:
         x: 247.70722025930104
         y: 65
       positionAbsolute:
-        x: 5648.707220259301
-        y: 1193
+        x: 5725.707220259301
+        y: 969
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1493,8 +1872,8 @@ workflow:
         x: 844.0068118865438
         y: 800.2561082923241
       positionAbsolute:
-        x: 6245.006811886544
-        y: 1928.2561082923241
+        x: 6322.006811886544
+        y: 1704.2561082923241
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1508,19 +1887,25 @@ workflow:
           - '1741512806512'
           - text
           variable: text
-        - value_selector: []
-          variable: ''
+        - value_selector:
+          - '1750995139153'
+          - text
+          variable: alertDirection
+        - value_selector:
+          - '1751601681225'
+          - text
+          variable: output
         selected: false
         title: End
         type: end
-      height: 90
+      height: 142
       id: '1741502839759'
       position:
-        x: 12047
-        y: 904
+        x: 15375
+        y: 1146
       positionAbsolute:
-        x: 12047
-        y: 904
+        x: 15375
+        y: 1146
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1537,8 +1922,8 @@ workflow:
           completion_params:
             temperature: 0.6
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: cd35fff4-a037-4e72-af99-2ff8299fc5d2
           role: system
@@ -1566,15 +1951,15 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '1741506766037'
       parentId: '1741497176064'
       position:
-        x: 3100.843852684704
-        y: 616.9747534648541
+        x: 3006.207221549953
+        y: 414.18197246181467
       positionAbsolute:
-        x: 8501.843852684704
-        y: 1744.974753464854
+        x: 8484.207221549954
+        y: 1318.1819724618147
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1582,29 +1967,19 @@ workflow:
       width: 244
       zIndex: 1002
     - data:
-        code: "import json\n\ndef main(arg: str) -> dict:\n    data = json.loads(arg)\n\
-          \    timeseries = data[\"data\"][\"timeseries\"]\n    \n    seen = set()\n\
-          \    pod_info = []\n    first_pod = \"{}\"\n    \n    for item in timeseries:\n\
-          \        labels = item[\"labels\"]\n        namespace = labels.get(\"namespace\"\
-          , \"\")\n        pod = labels.get(\"pod\", \"\")\n        pid = labels.get(\"\
-          pid\", \"\")\n        node = labels.get(\"node\", \"\")\n        if pid\
-          \ == '1':\n            continue\n \n        unique_key = (namespace, pod,\
-          \ pid)\n        \n        if unique_key not in seen:\n            seen.add(unique_key)\n\
-          \            info = {\n                \"namespace\": namespace,\n     \
-          \           \"pod\": pod,\n                \"pid\": pid,\n             \
-          \   \"node\": node\n            }\n            if first_pod == '{}':\n \
-          \               first_pod = json.dumps(info)\n            else:\n      \
-          \        pod_info.append(json.dumps(info))\n            \n    return {\n\
-          \        \"first\": first_pod,\n        \"monitor\": pod_info,\n    }"
+        code: "import json\n\ndef main(arg: list) -> dict:\n    pod_info = []\n  \
+          \  first_pod = None\n    \n    if len(arg) > 0:\n        first_pod = arg[0]\n\
+          \        pod_info = arg[1:]  \n    \n    return {\n        \"first\": first_pod,\n\
+          \        \"monitor\": pod_info,\n    }"
         code_language: python3
         desc: ''
         outputs:
           first:
             children: null
-            type: string
+            type: object
           monitor:
             children: null
-            type: array[string]
+            type: array[object]
         selected: false
         title: ' get pod info array'
         type: code
@@ -1616,11 +1991,11 @@ workflow:
       height: 54
       id: '1741509454645'
       position:
-        x: 1545
-        y: 543
+        x: 1844
+        y: 550
       positionAbsolute:
-        x: 1545
-        y: 543
+        x: 1844
+        y: 550
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1635,8 +2010,8 @@ workflow:
           completion_params:
             temperature: 0.6
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 169877de-aa4a-44db-90ef-2cc8f68882c4
           role: system
@@ -1682,22 +2057,21 @@ workflow:
 
             {{#17430596469370.text#}}
 
-            {{#1741497176064.output#}}
 
             '
         selected: false
-        title: summary data
+        title: 可行动方向建议
         type: llm
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '1741512806512'
       position:
-        x: 11744
+        x: 12041
         y: 904
       positionAbsolute:
-        x: 11744
+        x: 12041
         y: 904
       selected: false
       sourcePosition: right
@@ -1707,18 +2081,18 @@ workflow:
     - data:
         desc: ''
         selected: false
-        template: 服务名和节点均为空，无法分析根因。
+        template: 告警事件信息不足，无法进行根因分析
         title: unsupport alert
         type: template-transform
         variables: []
       height: 54
       id: '1741592094819'
       position:
-        x: 939
-        y: 359
+        x: 938
+        y: 440
       positionAbsolute:
-        x: 939
-        y: 359
+        x: 938
+        y: 440
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1737,11 +2111,11 @@ workflow:
       height: 90
       id: '1741592144815'
       position:
-        x: 1242
-        y: 359
+        x: 1240
+        y: 440
       positionAbsolute:
-        x: 1242
-        y: 359
+        x: 1240
+        y: 440
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1749,185 +2123,23 @@ workflow:
       width: 244
     - data:
         desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Specified service name
-            ja_JP: Specified service name
-            pt_BR: Specified service name
-            zh_Hans: 指定的服务名
-          label:
-            en_US: service_name
-            ja_JP: service_name
-            pt_BR: service_name
-            zh_Hans: service_name
-          llm_description: Specified service name
-          max: null
-          min: null
-          name: service_name
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query start time
-            ja_JP: Data query start time
-            pt_BR: Data query start time
-            zh_Hans: 开始时间 (微秒)
-          label:
-            en_US: startTime
-            ja_JP: startTime
-            pt_BR: startTime
-            zh_Hans: startTime
-          llm_description: Data query start time
-          max: null
-          min: null
-          name: startTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query end time
-            ja_JP: Data query end time
-            pt_BR: Data query end time
-            zh_Hans: 结束时间 (微秒)
-          label:
-            en_US: endTime
-            ja_JP: endTime
-            pt_BR: endTime
-            zh_Hans: endTime
-          llm_description: Data query start time
-          max: null
-          min: null
-          name: endTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        params:
-          endTime: ''
-          service_name: ''
-          startTime: ''
-        provider_id: apo_select
-        provider_name: apo_select
-        provider_type: builtin
+        output_type: array[object]
         selected: false
-        title: query pod info by service
-        tool_configurations: {}
-        tool_label: 列出该服务下的所有实例
-        tool_name: originx_service_instance
-        tool_parameters:
-          endTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - endTime
-          service_name:
-            type: mixed
-            value: '{{#1742807803325.service#}}'
-          startTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - startTime
-        type: tool
-      height: 54
-      id: '1741597223833'
-      position:
-        x: 939
-        y: 451
-      positionAbsolute:
-        x: 939
-        y: 451
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        desc: ''
-        output_type: string
-        selected: false
-        title: summary instance
+        title: 汇总实例数据
         type: variable-aggregator
         variables:
-        - - '1741597223833'
-          - text
-        - - '1741599658821'
+        - - '1750658174684'
           - result
-        - - '1742629595400'
-          - text
-      height: 153
+        - - '1750658087300'
+          - result
+      height: 130
       id: '1741597274153'
       position:
-        x: 1242
-        y: 511.5
+        x: 1542
+        y: 550
       positionAbsolute:
-        x: 1242
-        y: 511.5
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        code: "\ndef main(arg1: str, arg2: str, arg3: str) -> dict:\n    data = {\n\
-          \        \"data\": {\n            \"timeseries\": [\n                {\n\
-          \                    \"labels\": {\n                        \"namespace\"\
-          : arg2,\n                        \"pod\": arg1,\n                      \
-          \  \"pid\": arg3,\n                    }\n                }\n          \
-          \  ]\n        }\n    }\n    return {\n        \"result\": json.dumps(data),\n\
-          \    }\n"
-        code_language: python3
-        desc: ''
-        outputs:
-          result:
-            children: null
-            type: string
-        selected: false
-        title: get pod info
-        type: code
-        variables:
-        - value_selector:
-          - '1742807803325'
-          - pod
-          variable: arg1
-        - value_selector:
-          - '1742807803325'
-          - namespace
-          variable: arg2
-        - value_selector:
-          - '1742807803325'
-          - pid
-          variable: arg3
-      height: 54
-      id: '1741599658821'
-      position:
-        x: 939
-        y: 543
-      positionAbsolute:
-        x: 939
-        y: 543
+        x: 1542
+        y: 550
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1944,20 +2156,6 @@ workflow:
             variable_selector:
             - '1742807803325'
             - pod
-          - comparison_operator: not empty
-            id: add89997-787b-4d71-a187-3e9f8e8f25a3
-            value: ''
-            varType: string
-            variable_selector:
-            - '1742807803325'
-            - namespace
-          - comparison_operator: not empty
-            id: 21b420f6-cac6-4cf3-88b4-69ce01140ef8
-            value: ''
-            varType: string
-            variable_selector:
-            - '1742807803325'
-            - pid
           id: 'true'
           logical_operator: or
         - case_id: 2949ad86-bdc0-4b1d-bd84-6e01f41915eb
@@ -1968,32 +2166,57 @@ workflow:
             varType: string
             variable_selector:
             - '1742807803325'
-            - service
-          id: 2949ad86-bdc0-4b1d-bd84-6e01f41915eb
-          logical_operator: and
-        - case_id: 74dc1f70-729f-47e1-a6c8-9f0a1d2a6ad9
-          conditions:
+            - node
           - comparison_operator: not empty
-            id: a2f849d6-0c4f-40f0-9c91-f37cf81eb3f5
+            id: 1b6e0bb4-af9f-4b0e-a14a-aef80755a9a3
             value: ''
             varType: string
             variable_selector:
-            - '1741227526517'
-            - nodeName
-          id: 74dc1f70-729f-47e1-a6c8-9f0a1d2a6ad9
+            - '1742807803325'
+            - pid
+          id: 2949ad86-bdc0-4b1d-bd84-6e01f41915eb
+          logical_operator: and
+        - case_id: 6b6a21b2-be07-4596-8e1b-031dd9ad9055
+          conditions:
+          - comparison_operator: not empty
+            id: a43ade80-bf48-4397-a91e-9cbc261cf185
+            value: ''
+            varType: string
+            variable_selector:
+            - '1742807803325'
+            - node
+          - comparison_operator: not empty
+            id: 95210422-29ed-46df-b6ad-14022e303913
+            value: ''
+            varType: string
+            variable_selector:
+            - '1742807803325'
+            - containerId
+          id: 6b6a21b2-be07-4596-8e1b-031dd9ad9055
+          logical_operator: and
+        - case_id: 0b3c7ecb-381d-4c8b-acd0-496085d91807
+          conditions:
+          - comparison_operator: not empty
+            id: c3782e7c-7dcb-466d-924f-3f2e3af13a9c
+            value: ''
+            varType: string
+            variable_selector:
+            - '1742807803325'
+            - service
+          id: 0b3c7ecb-381d-4c8b-acd0-496085d91807
           logical_operator: and
         desc: ''
         selected: false
         title: alert instance info
         type: if-else
-      height: 274
+      height: 322
       id: '1742453019576'
       position:
         x: 636
-        y: 359
+        y: 440
       positionAbsolute:
         x: 636
-        y: 359
+        y: 440
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2137,159 +2360,17 @@ workflow:
       id: '1742547917612'
       parentId: '1741497176064'
       position:
-        x: 837.913049217997
-        y: 567.6173152328563
+        x: 836.4108804698271
+        y: 516.5435777950536
       positionAbsolute:
-        x: 6238.9130492179975
-        y: 1695.6173152328563
+        x: 6314.410880469827
+        y: 1420.5435777950536
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
       zIndex: 1002
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Specified node name
-            ja_JP: Specified node name
-            pt_BR: Specified pod name
-            zh_Hans: 指定的主机名称
-          label:
-            en_US: node_name
-            ja_JP: node_name
-            pt_BR: node_name
-            zh_Hans: node_name
-          llm_description: Specified pod name
-          max: null
-          min: null
-          name: node_name
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Specified Process ID
-            ja_JP: Specified Process ID
-            pt_BR: Specified Process ID
-            zh_Hans: 指定的进程ID
-          label:
-            en_US: pid
-            ja_JP: pid
-            pt_BR: pid
-            zh_Hans: pid
-          llm_description: Specified Process ID
-          max: null
-          min: null
-          name: pid
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query start time
-            ja_JP: Data query start time
-            pt_BR: Data query start time
-            zh_Hans: 开始时间 (微秒)
-          label:
-            en_US: startTime
-            ja_JP: startTime
-            pt_BR: startTime
-            zh_Hans: startTime
-          llm_description: Data query start time
-          max: null
-          min: null
-          name: startTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query end time
-            ja_JP: Data query end time
-            pt_BR: Data query end time
-            zh_Hans: 结束时间 (微秒)
-          label:
-            en_US: endTime
-            ja_JP: endTime
-            pt_BR: endTime
-            zh_Hans: endTime
-          llm_description: Data query start time
-          max: null
-          min: null
-          name: endTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        params:
-          endTime: ''
-          node_name: ''
-          pid: ''
-          startTime: ''
-        provider_id: apo_select
-        provider_name: apo_select
-        provider_type: builtin
-        selected: false
-        title: get pod info in node
-        tool_configurations: {}
-        tool_label: Thread Polaris Metrics Process All monitor
-        tool_name: originx_service_monitor
-        tool_parameters:
-          endTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - endTime
-          node_name:
-            type: mixed
-            value: '{{#1741227526517.nodeName#}}'
-          startTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - startTime
-        type: tool
-      height: 54
-      id: '1742629595400'
-      position:
-        x: 939
-        y: 635
-      positionAbsolute:
-        x: 939
-        y: 635
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
     - data:
         desc: ''
         isInIteration: true
@@ -2428,11 +2509,11 @@ workflow:
       id: '1742798505742'
       parentId: '1741497176064'
       position:
-        x: 838.2707565556775
-        y: 677.0915533804653
+        x: 830.759912814824
+        y: 627.5199846908333
       positionAbsolute:
-        x: 6239.2707565556775
-        y: 1805.0915533804653
+        x: 6308.759912814824
+        y: 1531.5199846908333
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2442,18 +2523,22 @@ workflow:
     - data:
         code: "def get_value(data, keys): \n  for key in keys: \n    value = data.get(key)\
           \ \n    if value is not None: \n      return value \n  return \"\" \n\n\
-          import json \n\ndef main(arg: str, node: str) -> dict:\n  data = json.loads(arg)\
-          \ \n  return { \n  \"alertName\": get_value(data, [\"alertName\"]),    \
+          import json \n\ndef main(arg: str, node: str) -> dict:\n  data = json.loads(arg)\n\
+          \  if node:\n    node = get_value(data,[\"node\", \"nodeName\", \"node_name\"\
+          ])\n  return { \n  \"alertName\": get_value(data, [\"alertName\"]),    \
           \  \n  \"service\": get_value(data, [\"svc_name\", \"service\"]), \n  \"\
           endpoint\": get_value(data,[\"endpoint\", \"content_key\"]), \n  \"pod\"\
           : get_value(data,[\"pod\", \"src_pod\", \"pod_name\"]), \n  \"namespace\"\
           : get_value(data,[\"namespace\", \"src_namespace\"]),\n  \"pid\": get_value(data,[\"\
-          pid\"]),\n  \"node\": node if node else get_value(data,[\"node\", \"nodeName\"\
-          , \"node_name\"]),\n  \"containerId\": get_value(data,[\"containerId\",\
-          \ \"container_id\"]),\n}"
+          pid\"]),\n  \"node\": node,\n  \"containerId\": get_value(data,[\"containerId\"\
+          , \"container_id\"]),\n  \"alertEventId\": get_value(data,[\"alertEventId\"\
+          ]),\n}"
         code_language: python3
         desc: ''
         outputs:
+          alertEventId:
+            children: null
+            type: string
           alertName:
             children: null
             type: string
@@ -2493,11 +2578,11 @@ workflow:
       height: 54
       id: '1742807803325'
       position:
-        x: 334.5801129819097
-        y: 359
+        x: 334
+        y: 440
       positionAbsolute:
-        x: 334.5801129819097
-        y: 359
+        x: 334
+        y: 440
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2668,11 +2753,11 @@ workflow:
       id: '1742980228913'
       parentId: '1741497176064'
       position:
-        x: 817.3433448742644
-        y: 386.77445077825655
+        x: 806.8281636370702
+        y: 209.51853849411827
       positionAbsolute:
-        x: 6218.343344874264
-        y: 1514.7744507782566
+        x: 6284.82816363707
+        y: 1113.5185384941183
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2844,11 +2929,11 @@ workflow:
       id: '1742980318484'
       parentId: '1741497176064'
       position:
-        x: 829.6661633624499
-        y: 478.0639330308825
+        x: 822.1553196215964
+        y: 365.4012769180829
       positionAbsolute:
-        x: 6230.66616336245
-        y: 1606.0639330308825
+        x: 6300.155319621596
+        y: 1269.4012769180829
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2971,11 +3056,11 @@ workflow:
       id: '1742980720651'
       parentId: '1741497176064'
       position:
-        x: 563.9711290826226
-        y: 320.3569405139135
+        x: 514.3995603929916
+        y: 213.7029593937964
       positionAbsolute:
-        x: 5964.971129082623
-        y: 1448.3569405139135
+        x: 5992.399560392992
+        y: 1117.7029593937964
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3098,11 +3183,11 @@ workflow:
       id: '1742980748320'
       parentId: '1741497176064'
       position:
-        x: 555.0492745306183
-        y: 435.2337750194638
+        x: 514.4907183300102
+        y: 357.1210001145894
       positionAbsolute:
-        x: 5956.049274530618
-        y: 1563.2337750194638
+        x: 5992.49071833001
+        y: 1261.1210001145894
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3225,11 +3310,11 @@ workflow:
       id: '1742980780865'
       parentId: '1741497176064'
       position:
-        x: 539.4805129111201
-        y: 551.2424325586171
+        x: 498.92195671051286
+        y: 507.6795388616679
       positionAbsolute:
-        x: 5940.48051291112
-        y: 1679.242432558617
+        x: 5976.921956710513
+        y: 1411.6795388616679
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3352,11 +3437,11 @@ workflow:
       id: '1742980837261'
       parentId: '1741497176064'
       position:
-        x: 513.7505744250511
-        y: 675.3340235425774
+        x: 498.72888694334415
+        y: 625.7624548529454
       positionAbsolute:
-        x: 5914.750574425051
-        y: 1803.3340235425774
+        x: 5976.728886943344
+        y: 1529.7624548529454
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3479,11 +3564,11 @@ workflow:
       id: '1742980885557'
       parentId: '1741497176064'
       position:
-        x: 514.5915555600113
-        y: 800.5850619112191
+        x: 484.5481805965983
+        y: 761.528674458782
       positionAbsolute:
-        x: 5915.591555560011
-        y: 1928.585061911219
+        x: 5962.548180596598
+        y: 1665.528674458782
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3491,15 +3576,19 @@ workflow:
       width: 244
       zIndex: 1002
     - data:
-        code: "\ndef main(arg1: str) -> dict:\n    data = json.loads(arg1)\n    return\
-          \ {\n        \"pod\": data.get(\"pod\", \"\"),\n        \"namespace\": data.get(\"\
-          namespace\", \"\"),\n        \"pid\": data.get(\"pid\", \"\")\n    }\n"
+        code: "\ndef main(data: dict) -> dict:\n    return {\n        \"pod\": data.get(\"\
+          podName\", \"\"),\n        \"namespace\": data.get(\"namespace\", \"\"),\n\
+          \        \"pid\": str(data.get(\"pid\", \"\")),\n        \"node\": data.get(\"\
+          nodeName\", \"\"),\n    }\n"
         code_language: python3
         desc: ''
         isInIteration: true
         iteration_id: '1741497176064'
         outputs:
           namespace:
+            children: null
+            type: string
+          node:
             children: null
             type: string
           pid:
@@ -3515,15 +3604,15 @@ workflow:
         - value_selector:
           - '1741509454645'
           - first
-          variable: arg1
+          variable: data
       height: 54
       id: '17430589567120'
       position:
-        x: 2182.496795992827
-        y: 687.8264418032278
+        x: 2448
+        y: 696
       positionAbsolute:
-        x: 2182.496795992827
-        y: 687.8264418032278
+        x: 2448
+        y: 696
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3648,11 +3737,11 @@ workflow:
       height: 54
       id: '17430595109950'
       position:
-        x: 3060
-        y: 904
+        x: 3354
+        y: 1019
       positionAbsolute:
-        x: 3060
-        y: 904
+        x: 3354
+        y: 1019
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3822,11 +3911,11 @@ workflow:
       height: 54
       id: '17430595158080'
       position:
-        x: 3363
-        y: 904
+        x: 3656
+        y: 1019
       positionAbsolute:
-        x: 3363
-        y: 904
+        x: 3656
+        y: 1019
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3844,8 +3933,8 @@ workflow:
           completion_params:
             temperature: 0.6
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: cd35fff4-a037-4e72-af99-2ff8299fc5d2
           role: system
@@ -3856,32 +3945,35 @@ workflow:
             \n# 输入数据规范\n- **分资源类别数据**：线程延迟及关联的北极星指标（如网络类延迟加上对应的异常网络网络链路延迟数据,不要忽略网络链路延迟数据）。\n\
             - **异常数据点计数**：延迟超过同类型线程历史均值20%的实例数，需标注线程延迟均值。\n\n# 分析规则\n1. **主异常方向判定**\n\
             - 标注异常线程的延迟均值。\n- 识别延迟增幅最显著的资源类型（如延迟从毫秒级跃升至秒级）。\n- **线程数量优先原则**：若某资源类型（如网络/epoll）的异常线程数量最多，则归因至该类别。请仔细分析各方向异常线程数量。\n\
-            *示例：网络/epoll类异常线程4条 vs CPU类2条 → 归因为网络方向问题。*\n\n2. **误判规避**\n- 若CPU或运行队列（RunQ）延迟突增且无并发网络/epoll异常，优先归因为CPU资源争用。\n\
-            \n3. **决胜优先级（降序）**\n'CPU > 网络 > Epoll > 文件 > RunQ'\n\n# 根因归因与建议\n- **CPU延迟突增**：检查代码过度嵌套问题，确认后执行版本回滚。\n\
-            - **CPU抢占过高**：排查同节点进程的资源争用。\n- **网络/Epoll延迟突增**：\n- 若网络链路延迟异常，比如有多条网络链路异常数据\
-            \ → 网络链路问题;\n- 若网络链路延迟正常，比如没有异常网络链路数据或者只有一条网络链路数据 → 下游服务延迟问题。\n- **文件操作延迟升高**：审计文件句柄泄漏。\n\
-            \n# 输出格式\n**应用实例**:{{#17430589567120.pod#}}  \n**北极星指标趋势摘要**\n- 按指标维度描述显著变化，若无异常标注\"\
-            未观测到显著偏离\"。\n\n**初步根因结论**\n- 明确告警事件对应用的影响状态。\n- 基于北极星指标与分析规则输出单一归因结论。\n\
-            *注：若网络/Epoll类异常但网络链路延迟正常，归因为下游服务延迟。*\n注： 如果对应方向有报告连接，需展示报告链接，可点击\n没有不用展示报告\n\
+            *示例：网络/epoll类异常线程4条 vs CPU类2条 → 归因为网络/Epoll延迟(需要结合网络ping给出下一步方向)*\n\n\
+            2. **误判规避**\n- 若CPU或运行队列（RunQ）延迟突增且无并发网络/epoll异常，优先归因为CPU资源争用。\n\n3. **决胜优先级（降序）**\n\
+            'CPU > 网络 > Epoll > 文件 > RunQ'\n\n# 根因归因与建议\n- **CPU延迟突增**：检查代码过度嵌套问题，确认后执行版本回滚。\n\
+            - **CPU抢占过高**：排查同节点进程的资源争用。\n- **网络/Epoll延迟**：需要给出进一步方向，如\n- 若网络ping指标异常，比如有多条网络rtt异常数据\
+            \ → 显示网络质量问题;\n- 若网络ping指标正常，比如没有异常网络质量数据或者只有一条网络质量数据 → 显示下游服务依赖延迟问题。\n\
+            - **文件操作延迟升高**：检查文件句柄是否打开过多。\n\n# 输出格式\n**应用实例**:{{#17430589567120.pod#}}\
+            \  \n**北极星指标趋势摘要**\n- 按指标维度描述显著变化，如xxx个线程xxxxx,若无异常标注\"未观测到显著偏离\"。\n-\
+            \ 描述网络Ping质量\n\n**初步根因结论**\n- 明确告警事件对应用的影响状态。\n- 基于北极星指标与分析规则输出单一归因结论。\n\
+            1. 若网络/Epoll类异常但网络链路延迟正常，归因为下游服务延迟。*\n2. 如果对应方向有报告连接，需展示报告链接，可点击\n没有不用展示报告\n\
             \n# 输入数据\n-cpu：{{#17443388433580.result#}}  \n- net：{{#17443388438160.result#}}\
             \  \n- file：{{#17443388421360.result#}}  \n- epoll：{{#1744290470304.result#}}\
-            \  \n- RunQ：{{#17443388443000.result#}}\n- 网络链路延迟（rtt）异常的数据：{{#1744255998058.result#}}\n\
-            \n#报告链接（说明是报告即可，不用关联线程）\n没有报告链接不用给出来\ncpu {{#1745388058502.text#}}\nnetwork方向\
-            \ {{#17453881280910.text#}}\nrunq方向 {{#17453881639600.text#}}\n\n# 输出准则\n\
-            - 使用简洁的非技术表述，避免歧义。\n- 结论需聚焦可执行建议（如\"检查代码嵌套\"而非\"可能存在性能问题\"）。"
+            \  \n- RunQ：{{#17443388443000.result#}}\n- 网络ping数据\n{{#17511674060740.text#}}\n\
+            (如果网络ping持续超过0.05s以上认为存在问题)\n\n#报告链接（说明是报告即可，不用关联线程）\n如果存在报告链接，必须把报告链接显示出来\n\
+            不要有遗漏，请仔细思考！！！\ncpu {{#1751504789699.text#}}\nnetwork方向 {{#17515048509810.text#}}\n\
+            runq方向 {{#17515048888700.text#}}\n\n# 输出准则\n- 使用简洁的非技术表述，避免歧义。\n- 结论需聚焦可执行建议（如\"\
+            检查代码嵌套\"而非\"可能存在性能问题\"）。"
         selected: false
         title: llm analysis root cause
         type: llm
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17430596469370'
       position:
-        x: 4878
+        x: 5174
         y: 904
       positionAbsolute:
-        x: 4878
+        x: 5174
         y: 904
       selected: false
       sourcePosition: right
@@ -4007,188 +4099,11 @@ workflow:
       height: 54
       id: '17430597987060'
       position:
-        x: 3363
-        y: 702
+        x: 3656
+        y: 696
       positionAbsolute:
-        x: 3363
-        y: 702
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-      zIndex: 1002
-    - data:
-        desc: ''
-        isInIteration: true
-        is_team_authorization: true
-        iteration_id: '1741497176064'
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: cAdvisor job name
-            ja_JP: cAdvisor job name
-            pt_BR: cAdvisor job name
-            zh_Hans: cAdvisor任务名称
-          label:
-            en_US: cAdvisor job name
-            ja_JP: cAdvisor job name
-            pt_BR: cAdvisor job name
-            zh_Hans: cAdvisor任务名称
-          llm_description: cAdvisor job name
-          max: null
-          min: null
-          name: cadvisor_job_name
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Namespace
-            ja_JP: Namespace
-            pt_BR: Namespace
-            zh_Hans: 命名空间
-          label:
-            en_US: Namespace
-            ja_JP: Namespace
-            pt_BR: Namespace
-            zh_Hans: 命名空间
-          llm_description: Namespace
-          max: null
-          min: null
-          name: namespace
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Pod name
-            ja_JP: Pod name
-            pt_BR: Pod name
-            zh_Hans: Pod名称
-          label:
-            en_US: Pod name
-            ja_JP: Pod name
-            pt_BR: Pod name
-            zh_Hans: Pod名称
-          llm_description: Pod name
-          max: null
-          min: null
-          name: pod
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query start time(Microsecond)
-            ja_JP: Data query start time(Microsecond)
-            pt_BR: Data query start time(Microsecond)
-            zh_Hans: 开始时间 (微秒)
-          label:
-            en_US: startTime
-            ja_JP: startTime
-            pt_BR: startTime
-            zh_Hans: startTime
-          llm_description: Data query start time(Microsecond)
-          max: null
-          min: null
-          name: startTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query end time(Microsecond)
-            ja_JP: Data query end time(Microsecond)
-            pt_BR: Data query end time(Microsecond)
-            zh_Hans: 结束时间 (微秒)
-          label:
-            en_US: endTime
-            ja_JP: endTime
-            pt_BR: endTime
-            zh_Hans: endTime
-          llm_description: Data query end time(Microsecond)
-          max: null
-          min: null
-          name: endTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        params:
-          cadvisor_job_name: ''
-          endTime: ''
-          namespace: ''
-          pod: ''
-          startTime: ''
-        provider_id: apo_select
-        provider_name: apo_select
-        provider_type: builtin
-        selected: false
-        title: container read disk
-        tool_configurations: {}
-        tool_label: Container disk read time per second (Containerd runtime, aggregated
-          by container and Pod)
-        tool_name: 容器磁盘读取耗时每秒(使用Containerd,按Pod和容器统计)
-        tool_parameters:
-          cadvisor_job_name:
-            type: mixed
-            value: ''
-          endTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - endTime
-          namespace:
-            type: mixed
-            value: '{{#17430589567120.namespace#}}'
-          pod:
-            type: mixed
-            value: '{{#17430589567120.pod#}}'
-          startTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - startTime
-        type: tool
-      height: 54
-      id: '17430598152780'
-      position:
-        x: 3666
-        y: 702
-      positionAbsolute:
-        x: 3666
-        y: 702
+        x: 3656
+        y: 696
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4313,11 +4228,11 @@ workflow:
       height: 54
       id: '17430598907140'
       position:
-        x: 2757
-        y: 1032
+        x: 3052
+        y: 1113
       positionAbsolute:
-        x: 2757
-        y: 1032
+        x: 3052
+        y: 1113
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4454,10 +4369,10 @@ workflow:
             value: '{{#17430589567120.namespace#}}'
           node:
             type: mixed
-            value: '{{#1742807803325.node#}}'
+            value: '{{#17430589567120.node#}}'
           pid:
             type: mixed
-            value: '{{#1742807803325.pid#}}'
+            value: '{{#17430589567120.pid#}}'
           pod:
             type: mixed
             value: '{{#17430589567120.pod#}}'
@@ -4470,11 +4385,11 @@ workflow:
       height: 54
       id: '17430598942980'
       position:
-        x: 3060
-        y: 1032
+        x: 3354
+        y: 1113
       positionAbsolute:
-        x: 3060
-        y: 1032
+        x: 3354
+        y: 1113
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4599,11 +4514,11 @@ workflow:
       height: 54
       id: '17430610599980'
       position:
-        x: 3060
-        y: 794
+        x: 3354
+        y: 790
       positionAbsolute:
-        x: 3060
-        y: 794
+        x: 3354
+        y: 790
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4740,10 +4655,10 @@ workflow:
             value: '{{#17430589567120.namespace#}}'
           node:
             type: mixed
-            value: '{{#1742807803325.node#}}'
+            value: '{{#17430589567120.node#}}'
           pid:
             type: mixed
-            value: '{{#1742807803325.pid#}}'
+            value: '{{#17430589567120.pid#}}'
           pod:
             type: mixed
             value: '{{#17430589567120.pod#}}'
@@ -4756,11 +4671,11 @@ workflow:
       height: 54
       id: '17430610640640'
       position:
-        x: 3363
-        y: 794
+        x: 3656
+        y: 790
       positionAbsolute:
-        x: 3363
-        y: 794
+        x: 3656
+        y: 790
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4882,11 +4797,11 @@ workflow:
       height: 54
       id: '17430610719970'
       position:
-        x: 3060
-        y: 1160
+        x: 3354
+        y: 1359
       positionAbsolute:
-        x: 3060
-        y: 1160
+        x: 3354
+        y: 1359
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5030,11 +4945,11 @@ workflow:
       height: 54
       id: '17430610756270'
       position:
-        x: 3363
-        y: 1160
+        x: 3656
+        y: 1359
       positionAbsolute:
-        x: 3363
-        y: 1160
+        x: 3656
+        y: 1359
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5071,11 +4986,11 @@ workflow:
       height: 54
       id: '1744255998058'
       position:
-        x: 3666
-        y: 794
+        x: 3959
+        y: 790
       positionAbsolute:
-        x: 3666
-        y: 794
+        x: 3959
+        y: 790
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5111,11 +5026,11 @@ workflow:
       height: 54
       id: '17442560822670'
       position:
-        x: 3363
-        y: 1032
+        x: 3656
+        y: 1113
       positionAbsolute:
-        x: 3363
-        y: 1032
+        x: 3656
+        y: 1113
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5206,8 +5121,8 @@ workflow:
         type: code
         variables:
         - value_selector:
-          - '1745323059455'
-          - text
+          - '17511127594560'
+          - result
           variable: data_json
         - value_selector:
           - '1744255998058'
@@ -5216,11 +5131,11 @@ workflow:
       height: 54
       id: '1744287265980'
       position:
-        x: 4272
-        y: 794
+        x: 4567
+        y: 790
       positionAbsolute:
-        x: 4272
-        y: 794
+        x: 4567
+        y: 790
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5262,11 +5177,11 @@ workflow:
       height: 54
       id: '1744290470304'
       position:
-        x: 4575
-        y: 794
+        x: 4871
+        y: 790
       positionAbsolute:
-        x: 4575
-        y: 794
+        x: 4871
+        y: 790
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5357,8 +5272,8 @@ workflow:
         type: code
         variables:
         - value_selector:
-          - '1745323078946'
-          - text
+          - '17511129103380'
+          - result
           variable: data_json
         - value_selector:
           - '17430610756270'
@@ -5367,11 +5282,11 @@ workflow:
       height: 54
       id: '17443356883380'
       position:
-        x: 3969
-        y: 1160
+        x: 4263
+        y: 1360
       positionAbsolute:
-        x: 3969
-        y: 1160
+        x: 4263
+        y: 1360
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5462,8 +5377,8 @@ workflow:
         type: code
         variables:
         - value_selector:
-          - '1745323124559'
-          - text
+          - '17511128736240'
+          - result
           variable: data_json
         - value_selector:
           - '17442560822670'
@@ -5472,11 +5387,11 @@ workflow:
       height: 54
       id: '17443357536900'
       position:
-        x: 3969
-        y: 1032
+        x: 4263
+        y: 1114
       positionAbsolute:
-        x: 3969
-        y: 1032
+        x: 4263
+        y: 1114
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5567,21 +5482,21 @@ workflow:
         type: code
         variables:
         - value_selector:
-          - '1745323119371'
-          - text
+          - '1751112705936'
+          - result
           variable: data_json
         - value_selector:
-          - '17430598152780'
+          - '1750661176423'
           - text
           variable: proof_json
       height: 54
       id: '17443357893440'
       position:
-        x: 4272
-        y: 702
+        x: 4567
+        y: 696
       positionAbsolute:
-        x: 4272
-        y: 702
+        x: 4567
+        y: 696
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5672,8 +5587,8 @@ workflow:
         type: code
         variables:
         - value_selector:
-          - '1745323114690'
-          - text
+          - '17511128355920'
+          - result
           variable: data_json
         - value_selector:
           - '17430595158080'
@@ -5682,11 +5597,11 @@ workflow:
       height: 54
       id: '17443357899060'
       position:
-        x: 3969
-        y: 904
+        x: 4263
+        y: 1020
       positionAbsolute:
-        x: 3969
-        y: 904
+        x: 4263
+        y: 1020
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5728,11 +5643,11 @@ workflow:
       height: 54
       id: '17443388421360'
       position:
-        x: 4575
-        y: 702
+        x: 4871
+        y: 696
       positionAbsolute:
-        x: 4575
-        y: 702
+        x: 4871
+        y: 696
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5774,11 +5689,11 @@ workflow:
       height: 54
       id: '17443388433580'
       position:
-        x: 4272
-        y: 904
+        x: 4567
+        y: 1019
       positionAbsolute:
-        x: 4272
-        y: 904
+        x: 4567
+        y: 1019
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5820,11 +5735,11 @@ workflow:
       height: 54
       id: '17443388438160'
       position:
-        x: 4272
-        y: 1032
+        x: 4567
+        y: 1113
       positionAbsolute:
-        x: 4272
-        y: 1032
+        x: 4567
+        y: 1113
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5866,11 +5781,11 @@ workflow:
       height: 54
       id: '17443388443000'
       position:
-        x: 4272
-        y: 1160
+        x: 4567
+        y: 1359
       positionAbsolute:
-        x: 4272
-        y: 1160
+        x: 4567
+        y: 1359
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5909,11 +5824,11 @@ workflow:
       id: '1744342068305'
       parentId: '1741497176064'
       position:
-        x: 1163.2885127206846
-        y: 673.674875984598
+        x: 1151.2711627353192
+        y: 627.1076447913074
       positionAbsolute:
-        x: 6564.288512720685
-        y: 1801.674875984598
+        x: 6629.271162735319
+        y: 1531.1076447913074
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5953,11 +5868,11 @@ workflow:
       id: '1744342138380'
       parentId: '1741497176064'
       position:
-        x: 1183.3553424127522
-        y: 574.6824876720586
+        x: 1156.3163049456798
+        y: 510.0892315007202
       positionAbsolute:
-        x: 6584.355342412752
-        y: 1702.6824876720586
+        x: 6634.31630494568
+        y: 1414.0892315007202
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6062,11 +5977,11 @@ workflow:
       id: '1744342244843'
       parentId: '1741497176064'
       position:
-        x: 1791.8192785924111
-        y: 371.13327676062727
+        x: 1700.1869849540008
+        y: 204.3925457136836
       positionAbsolute:
-        x: 7192.819278592411
-        y: 1499.1332767606273
+        x: 7178.186984954001
+        y: 1108.3925457136836
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6171,11 +6086,11 @@ workflow:
       id: '1744342309386'
       parentId: '1741497176064'
       position:
-        x: 1790.2988857309501
-        y: 472.94697102100463
+        x: 1703.1730983370517
+        y: 349.7691336710102
       positionAbsolute:
-        x: 7191.29888573095
-        y: 1600.9469710210046
+        x: 7181.173098337052
+        y: 1253.7691336710102
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6280,11 +6195,11 @@ workflow:
       id: '1744342372882'
       parentId: '1741497176064'
       position:
-        x: 2092.972416533212
-        y: 575.9896449249493
+        x: 1987.8206041612648
+        y: 524.9159074871468
       positionAbsolute:
-        x: 7493.972416533212
-        y: 1703.9896449249493
+        x: 7465.820604161265
+        y: 1428.9159074871468
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6389,11 +6304,11 @@ workflow:
       id: '1744342426374'
       parentId: '1741497176064'
       position:
-        x: 2092.4007677668633
-        y: 671.2138333819241
+        x: 2002.2706428766232
+        y: 621.6422646922922
       positionAbsolute:
-        x: 7493.400767766863
-        y: 1799.2138333819241
+        x: 7480.270642876623
+        y: 1525.6422646922922
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6498,11 +6413,11 @@ workflow:
       id: '1744342478278'
       parentId: '1741497176064'
       position:
-        x: 1768.3401312758333
-        y: 804.853363697991
+        x: 1518.9801190795033
+        y: 794.3381824607964
       positionAbsolute:
-        x: 7169.340131275833
-        y: 1932.853363697991
+        x: 6996.980119079503
+        y: 1698.3381824607964
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6548,11 +6463,11 @@ workflow:
       id: '1744342609856'
       parentId: '1741497176064'
       position:
-        x: 2075.340131275834
-        y: 804.853363697991
+        x: 1994.223018874618
+        y: 818.3728824315269
       positionAbsolute:
-        x: 7476.340131275834
-        y: 1932.853363697991
+        x: 7472.223018874618
+        y: 1722.372882431527
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6598,11 +6513,11 @@ workflow:
       id: '1744342800777'
       parentId: '1741497176064'
       position:
-        x: 2396.2516631873705
-        y: 671.1408594726702
+        x: 2373.719131964811
+        y: 609.5519407976731
       positionAbsolute:
-        x: 7797.2516631873705
-        y: 1799.1408594726702
+        x: 7851.719131964811
+        y: 1513.551940797673
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6648,11 +6563,11 @@ workflow:
       id: '1744342846753'
       parentId: '1741497176064'
       position:
-        x: 2397.0575190597137
-        y: 573.1165915837507
+        x: 2379.031494081666
+        y: 522.042854145948
       positionAbsolute:
-        x: 7798.057519059714
-        y: 1701.1165915837507
+        x: 7857.031494081666
+        y: 1426.042854145948
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6698,11 +6613,11 @@ workflow:
       id: '1744342890395'
       parentId: '1741497176064'
       position:
-        x: 2298.297497136483
-        y: 475.73311174167225
+        x: 2220.1847222316082
+        y: 342.0400931544832
       positionAbsolute:
-        x: 7699.297497136483
-        y: 1603.7331117416722
+        x: 7698.184722231608
+        y: 1246.0400931544832
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6748,302 +6663,17 @@ workflow:
       id: '1744342920172'
       parentId: '1741497176064'
       position:
-        x: 2291.073286368818
-        y: 355.5973351437458
+        x: 2253.5190676645516
+        y: 214.3934728157035
       positionAbsolute:
-        x: 7692.073286368818
-        y: 1483.5973351437458
+        x: 7731.519067664552
+        y: 1118.3934728157035
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
       zIndex: 1002
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          label:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          llm_description: Metrics query result
-          max: null
-          min: null
-          name: result
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        params:
-          result: ''
-        provider_id: apo_analysis
-        provider_name: apo_analysis
-        provider_type: builtin
-        selected: false
-        title: 分析图表的异常样本
-        tool_configurations: {}
-        tool_label: 分析图表的异常样本
-        tool_name: abnormal charts
-        tool_parameters:
-          result:
-            type: mixed
-            value: '{{#17430610599980.text#}}'
-        type: tool
-      height: 54
-      id: '1745323059455'
-      position:
-        x: 3969
-        y: 794
-      positionAbsolute:
-        x: 3969
-        y: 794
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          label:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          llm_description: Metrics query result
-          max: null
-          min: null
-          name: result
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        params:
-          result: ''
-        provider_id: apo_analysis
-        provider_name: apo_analysis
-        provider_type: builtin
-        selected: false
-        title: 分析图表的异常样本
-        tool_configurations: {}
-        tool_label: 分析图表的异常样本
-        tool_name: abnormal charts
-        tool_parameters:
-          result:
-            type: mixed
-            value: '{{#17430610719970.text#}}'
-        type: tool
-      height: 54
-      id: '1745323078946'
-      position:
-        x: 3666
-        y: 1160
-      positionAbsolute:
-        x: 3666
-        y: 1160
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          label:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          llm_description: Metrics query result
-          max: null
-          min: null
-          name: result
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        params:
-          result: ''
-        provider_id: apo_analysis
-        provider_name: apo_analysis
-        provider_type: builtin
-        selected: false
-        title: 分析图表的异常样本
-        tool_configurations: {}
-        tool_label: 分析图表的异常样本
-        tool_name: abnormal charts
-        tool_parameters:
-          result:
-            type: mixed
-            value: '{{#17430595109950.text#}}'
-        type: tool
-      height: 54
-      id: '1745323114690'
-      position:
-        x: 3666
-        y: 904
-      positionAbsolute:
-        x: 3666
-        y: 904
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          label:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          llm_description: Metrics query result
-          max: null
-          min: null
-          name: result
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        params:
-          result: ''
-        provider_id: apo_analysis
-        provider_name: apo_analysis
-        provider_type: builtin
-        selected: false
-        title: 分析图表的异常样本
-        tool_configurations: {}
-        tool_label: 分析图表的异常样本
-        tool_name: abnormal charts
-        tool_parameters:
-          result:
-            type: mixed
-            value: '{{#17430597987060.text#}}'
-        type: tool
-      height: 54
-      id: '1745323119371'
-      position:
-        x: 3969
-        y: 702
-      positionAbsolute:
-        x: 3969
-        y: 702
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          label:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          llm_description: Metrics query result
-          max: null
-          min: null
-          name: result
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        params:
-          result: ''
-        provider_id: apo_analysis
-        provider_name: apo_analysis
-        provider_type: builtin
-        selected: false
-        title: 分析图表的异常样本
-        tool_configurations: {}
-        tool_label: 分析图表的异常样本
-        tool_name: abnormal charts
-        tool_parameters:
-          result:
-            type: mixed
-            value: '{{#17430598907140.text#}}'
-        type: tool
-      height: 54
-      id: '1745323124559'
-      position:
-        x: 3666
-        y: 1032
-      positionAbsolute:
-        x: 3666
-        y: 1032
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
     - data:
         desc: ''
         isInIteration: true
@@ -7094,11 +6724,11 @@ workflow:
       id: '1745325937486'
       parentId: '1741497176064'
       position:
-        x: 1120.3433448742644
-        y: 386.77445077825655
+        x: 1121.8455136224347
+        y: 209.51853849411827
       positionAbsolute:
-        x: 6521.343344874264
-        y: 1514.7744507782566
+        x: 6599.845513622435
+        y: 1113.5185384941183
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7155,11 +6785,11 @@ workflow:
       id: '1745326017289'
       parentId: '1741497176064'
       position:
-        x: 1132.6661633624499
-        y: 478.0639330308825
+        x: 1137.1726696069618
+        y: 357.8904331772294
       positionAbsolute:
-        x: 6533.66616336245
-        y: 1606.0639330308825
+        x: 6615.172669606962
+        y: 1261.8904331772294
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7216,11 +6846,11 @@ workflow:
       id: '1745326029444'
       parentId: '1741497176064'
       position:
-        x: 1486.3553424127522
-        y: 574.6824876720586
+        x: 1487.8575111609225
+        y: 514.5957377452321
       positionAbsolute:
-        x: 6887.355342412752
-        y: 1702.6824876720586
+        x: 6965.8575111609225
+        y: 1418.595737745232
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7277,11 +6907,11 @@ workflow:
       id: '1745326038950'
       parentId: '1741497176064'
       position:
-        x: 1466.2885127206846
-        y: 673.674875984598
+        x: 1481.3102002023916
+        y: 616.5924635541128
       positionAbsolute:
-        x: 6867.288512720685
-        y: 1801.674875984598
+        x: 6959.310200202392
+        y: 1520.5924635541128
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7341,8 +6971,8 @@ workflow:
         x: 1147.0068118865438
         y: 800.2561082923241
       positionAbsolute:
-        x: 6548.006811886544
-        y: 1928.2561082923241
+        x: 6625.006811886544
+        y: 1704.2561082923241
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7350,557 +6980,10 @@ workflow:
       width: 244
       zIndex: 1002
     - data:
-        default_value:
-        - key: text
-          type: string
-          value: ''
-        - key: json
-          type: array[object]
-          value: '[]'
-        desc: ''
-        error_strategy: default-value
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Service name
-            ja_JP: Service name
-            pt_BR: Service name
-            zh_Hans: 业务服务名称
-          label:
-            en_US: Service name
-            ja_JP: Service name
-            pt_BR: Service name
-            zh_Hans: 业务服务名称
-          llm_description: Service name
-          max: null
-          min: null
-          name: service
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: endpoint
-            ja_JP: endpoint
-            pt_BR: endpoint
-            zh_Hans: 业务服务端点
-          label:
-            en_US: endpoint
-            ja_JP: endpoint
-            pt_BR: endpoint
-            zh_Hans: 业务服务端点
-          llm_description: endpoint
-          max: null
-          min: null
-          name: endpoint
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Type (cpu,net,file,runq)
-            ja_JP: Type (cpu,net,file,runq)
-            pt_BR: Type (cpu,net,file,runq)
-            zh_Hans: 报告类型(cpu,net,file,runq)
-          label:
-            en_US: Type (cpu,net,file,runq)
-            ja_JP: Type (cpu,net,file,runq)
-            pt_BR: Type (cpu,net,file,runq)
-            zh_Hans: 报告类型(cpu,net,file,runq)
-          llm_description: Type (cpu,net,file,runq)
-          max: null
-          min: null
-          name: type
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query start time(Microsecond)
-            ja_JP: Data query start time(Microsecond)
-            pt_BR: Data query start time
-            zh_Hans: 开始时间 (微秒)
-          label:
-            en_US: startTime
-            ja_JP: startTime
-            pt_BR: startTime
-            zh_Hans: startTime
-          llm_description: Data query start time(Microsecond)
-          max: null
-          min: null
-          name: startTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query end time(Microsecond)
-            ja_JP: Data query end time(Microsecond)
-            pt_BR: Data query end time(Microsecond)
-            zh_Hans: 结束时间 (微秒)
-          label:
-            en_US: endTime
-            ja_JP: endTime
-            pt_BR: endTime
-            zh_Hans: endTime
-          llm_description: Data query end time(Microsecond)
-          max: null
-          min: null
-          name: endTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        params:
-          endTime: ''
-          endpoint: ''
-          service: ''
-          startTime: ''
-          type: ''
-        provider_id: apo_select
-        provider_name: apo_select
-        provider_type: builtin
-        selected: false
-        title: 查询CPU根因报告
-        tool_configurations: {}
-        tool_label: 查询服务根因报告
-        tool_name: 查询服务根因报告
-        tool_parameters:
-          endTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - endTime
-          endpoint:
-            type: mixed
-            value: '{{#1742807803325.endpoint#}}'
-          service:
-            type: mixed
-            value: '{{#1742807803325.service#}}'
-          startTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - startTime
-          type:
-            type: mixed
-            value: cpu_time
-        type: tool
-      height: 90
-      id: '1745388058502'
-      position:
-        x: 4575
-        y: 886
-      positionAbsolute:
-        x: 4575
-        y: 886
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        default_value:
-        - key: text
-          type: string
-          value: ''
-        - key: json
-          type: array[object]
-          value: '[]'
-        desc: ''
-        error_strategy: default-value
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Service name
-            ja_JP: Service name
-            pt_BR: Service name
-            zh_Hans: 业务服务名称
-          label:
-            en_US: Service name
-            ja_JP: Service name
-            pt_BR: Service name
-            zh_Hans: 业务服务名称
-          llm_description: Service name
-          max: null
-          min: null
-          name: service
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: endpoint
-            ja_JP: endpoint
-            pt_BR: endpoint
-            zh_Hans: 业务服务端点
-          label:
-            en_US: endpoint
-            ja_JP: endpoint
-            pt_BR: endpoint
-            zh_Hans: 业务服务端点
-          llm_description: endpoint
-          max: null
-          min: null
-          name: endpoint
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Type (cpu,net,file,runq)
-            ja_JP: Type (cpu,net,file,runq)
-            pt_BR: Type (cpu,net,file,runq)
-            zh_Hans: 报告类型(cpu,net,file,runq)
-          label:
-            en_US: Type (cpu,net,file,runq)
-            ja_JP: Type (cpu,net,file,runq)
-            pt_BR: Type (cpu,net,file,runq)
-            zh_Hans: 报告类型(cpu,net,file,runq)
-          llm_description: Type (cpu,net,file,runq)
-          max: null
-          min: null
-          name: type
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query start time(Microsecond)
-            ja_JP: Data query start time(Microsecond)
-            pt_BR: Data query start time
-            zh_Hans: 开始时间 (微秒)
-          label:
-            en_US: startTime
-            ja_JP: startTime
-            pt_BR: startTime
-            zh_Hans: startTime
-          llm_description: Data query start time(Microsecond)
-          max: null
-          min: null
-          name: startTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query end time(Microsecond)
-            ja_JP: Data query end time(Microsecond)
-            pt_BR: Data query end time(Microsecond)
-            zh_Hans: 结束时间 (微秒)
-          label:
-            en_US: endTime
-            ja_JP: endTime
-            pt_BR: endTime
-            zh_Hans: endTime
-          llm_description: Data query end time(Microsecond)
-          max: null
-          min: null
-          name: endTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        params:
-          endTime: ''
-          endpoint: ''
-          service: ''
-          startTime: ''
-          type: ''
-        provider_id: apo_select
-        provider_name: apo_select
-        provider_type: builtin
-        retry_config:
-          max_retries: 3
-          retry_enabled: false
-          retry_interval: 1000
-        selected: false
-        title: 查询Net根因报告
-        tool_configurations: {}
-        tool_label: 查询服务根因报告
-        tool_name: 查询服务根因报告
-        tool_parameters:
-          endTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - endTime
-          endpoint:
-            type: mixed
-            value: '{{#1742807803325.endpoint#}}'
-          service:
-            type: mixed
-            value: '{{#1742807803325.service#}}'
-          startTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - startTime
-          type:
-            type: mixed
-            value: network_time
-        type: tool
-      height: 90
-      id: '17453881280910'
-      position:
-        x: 4575
-        y: 1014
-      positionAbsolute:
-        x: 4575
-        y: 1014
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        default_value:
-        - key: text
-          type: string
-          value: ''
-        - key: json
-          type: array[object]
-          value: '[]'
-        desc: ''
-        error_strategy: default-value
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Service name
-            ja_JP: Service name
-            pt_BR: Service name
-            zh_Hans: 业务服务名称
-          label:
-            en_US: Service name
-            ja_JP: Service name
-            pt_BR: Service name
-            zh_Hans: 业务服务名称
-          llm_description: Service name
-          max: null
-          min: null
-          name: service
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: endpoint
-            ja_JP: endpoint
-            pt_BR: endpoint
-            zh_Hans: 业务服务端点
-          label:
-            en_US: endpoint
-            ja_JP: endpoint
-            pt_BR: endpoint
-            zh_Hans: 业务服务端点
-          llm_description: endpoint
-          max: null
-          min: null
-          name: endpoint
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Type (cpu,net,file,runq)
-            ja_JP: Type (cpu,net,file,runq)
-            pt_BR: Type (cpu,net,file,runq)
-            zh_Hans: 报告类型(cpu,net,file,runq)
-          label:
-            en_US: Type (cpu,net,file,runq)
-            ja_JP: Type (cpu,net,file,runq)
-            pt_BR: Type (cpu,net,file,runq)
-            zh_Hans: 报告类型(cpu,net,file,runq)
-          llm_description: Type (cpu,net,file,runq)
-          max: null
-          min: null
-          name: type
-          options: []
-          placeholder: null
-          precision: null
-          required: false
-          scope: null
-          template: null
-          type: string
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query start time(Microsecond)
-            ja_JP: Data query start time(Microsecond)
-            pt_BR: Data query start time
-            zh_Hans: 开始时间 (微秒)
-          label:
-            en_US: startTime
-            ja_JP: startTime
-            pt_BR: startTime
-            zh_Hans: startTime
-          llm_description: Data query start time(Microsecond)
-          max: null
-          min: null
-          name: startTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: Data query end time(Microsecond)
-            ja_JP: Data query end time(Microsecond)
-            pt_BR: Data query end time(Microsecond)
-            zh_Hans: 结束时间 (微秒)
-          label:
-            en_US: endTime
-            ja_JP: endTime
-            pt_BR: endTime
-            zh_Hans: endTime
-          llm_description: Data query end time(Microsecond)
-          max: null
-          min: null
-          name: endTime
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: number
-        params:
-          endTime: ''
-          endpoint: ''
-          service: ''
-          startTime: ''
-          type: ''
-        provider_id: apo_select
-        provider_name: apo_select
-        provider_type: builtin
-        selected: false
-        title: 查询runq根因报告
-        tool_configurations: {}
-        tool_label: 查询服务根因报告
-        tool_name: 查询服务根因报告
-        tool_parameters:
-          endTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - endTime
-          endpoint:
-            type: mixed
-            value: '{{#1742807803325.endpoint#}}'
-          service:
-            type: mixed
-            value: '{{#1742807803325.service#}}'
-          startTime:
-            type: variable
-            value:
-            - '1741227526517'
-            - startTime
-          type:
-            type: mixed
-            value: scheduling_time
-        type: tool
-      height: 90
-      id: '17453881639600'
-      position:
-        x: 4575
-        y: 1142
-      positionAbsolute:
-        x: 4575
-        y: 1142
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
         cases:
         - case_id: 'true'
           conditions:
-          - comparison_operator: is not
+          - comparison_operator: not empty
             id: a442dabe-ea1e-43c5-b85b-8e053695ff5a
             value: '{}'
             varType: string
@@ -7911,16 +6994,16 @@ workflow:
           logical_operator: and
         desc: ''
         selected: false
-        title: 条件分支 2
+        title: 是否获取监控实例
         type: if-else
       height: 126
       id: '1745494305165'
       position:
-        x: 1848
-        y: 543
+        x: 2146
+        y: 550
       positionAbsolute:
-        x: 1848
-        y: 543
+        x: 2146
+        y: 550
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7929,18 +7012,18 @@ workflow:
     - data:
         desc: ''
         selected: false
-        template: 未查询到告警关联的服务程序，请检查apo-one-agent是否安装并监控服务。
+        template: 未查询到告警关联的服务实例，请检查apo-one-agent是否安装并监控服务。
         title: 未查询到关联服务
         type: template-transform
         variables: []
       height: 54
       id: '1745494335273'
       position:
-        x: 2151
-        y: 543
+        x: 2448
+        y: 550
       positionAbsolute:
-        x: 2151
-        y: 543
+        x: 2448
+        y: 550
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7959,11 +7042,11 @@ workflow:
       height: 90
       id: '1745494338512'
       position:
-        x: 2454
-        y: 543
+        x: 2750
+        y: 550
       positionAbsolute:
-        x: 2454
-        y: 543
+        x: 2750
+        y: 550
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7973,34 +7056,27 @@ workflow:
         cases:
         - case_id: 'true'
           conditions:
-          - comparison_operator: contains
-            id: c3fbfa86-caf9-4f75-94f5-2df1dae0ee50
-            value: 下游依赖耗时
+          - comparison_operator: empty
+            id: 2d60776c-0f94-45b3-b40c-e51355aa7c0d
+            value: ''
             varType: string
             variable_selector:
-            - '1742807803325'
-            - alertName
-          - comparison_operator: contains
-            id: e7fe1ff9-6001-4551-a560-c9dcf98b1f37
-            value: 响应耗时
-            varType: string
-            variable_selector:
-            - '1742807803325'
-            - alertName
+            - '1741227526517'
+            - params
           id: 'true'
           logical_operator: or
         desc: ''
         selected: false
         title: 告警初步方向分析
         type: if-else
-      height: 152
+      height: 126
       id: '1747355869184'
       position:
-        x: 2454
-        y: 671
+        x: 2750
+        y: 678
       positionAbsolute:
-        x: 2454
-        y: 671
+        x: 2750
+        y: 678
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -8150,11 +7226,11 @@ workflow:
       height: 54
       id: '1747355986489'
       position:
-        x: 2755.3795535397207
-        y: 1270
+        x: 3052
+        y: 1236
       positionAbsolute:
-        x: 2755.3795535397207
-        y: 1270
+        x: 3052
+        y: 1236
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -8306,11 +7382,11 @@ workflow:
       height: 54
       id: '17473562733380'
       position:
-        x: 2757
-        y: 1362
+        x: 4263
+        y: 905
       positionAbsolute:
-        x: 2757
-        y: 1362
+        x: 4263
+        y: 905
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -8364,68 +7440,11 @@ workflow:
       height: 54
       id: '17473564423850'
       position:
-        x: 3060
-        y: 1270
+        x: 3354
+        y: 1236
       positionAbsolute:
-        x: 3060
-        y: 1270
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        desc: ''
-        is_team_authorization: true
-        output_schema: null
-        paramSchemas:
-        - auto_generate: null
-          default: null
-          form: llm
-          human_description:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          label:
-            en_US: 指标查询结果
-            ja_JP: 指标查询结果
-            pt_BR: 指标查询结果
-            zh_Hans: Metrics query result
-          llm_description: Metrics query result
-          max: null
-          min: null
-          name: result
-          options: []
-          placeholder: null
-          precision: null
-          required: true
-          scope: null
-          template: null
-          type: string
-        params:
-          result: ''
-        provider_id: apo_analysis
-        provider_name: apo_analysis
-        provider_type: builtin
-        selected: false
-        title: 分析RTT消耗的异常样本
-        tool_configurations: {}
-        tool_label: 分析图表的异常样本
-        tool_name: abnormal charts
-        tool_parameters:
-          result:
-            type: mixed
-            value: '{{#17473562733380.text#}}'
-        type: tool
-      height: 54
-      id: '17473564454180'
-      position:
-        x: 3060
-        y: 1362
-      positionAbsolute:
-        x: 3060
-        y: 1362
+        x: 3354
+        y: 1236
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -8478,69 +7497,11 @@ workflow:
       height: 54
       id: '1747356893645'
       position:
-        x: 3363
-        y: 1270
+        x: 3656
+        y: 1236
       positionAbsolute:
-        x: 3363
-        y: 1270
-      selected: false
-      sourcePosition: right
-      targetPosition: left
-      type: custom
-      width: 244
-    - data:
-        code: "import json\n\ndef main(data_json):\n    data = json.loads(data_json)\n\
-          \    \n    for instance in data:\n        chart = instance['chart']\n  \
-          \      abnormal_count = instance['abnormalCount']\n        \n        # 计算\
-          \ abnormal_mean\n        sorted_values = sorted(chart.values(), reverse=True)\n\
-          \        top_abnormal_values = sorted_values[:abnormal_count]\n        mean_abnormal\
-          \ = sum(top_abnormal_values) / abnormal_count if abnormal_count > 0 else\
-          \ 0\n        instance[\"abnormal_mean\"] = mean_abnormal\n        \n   \
-          \     # 计算 abnormal_avg_growth\n        sorted_timestamps = sorted(chart.keys())\
-          \  # 按时间戳升序排列\n        time_to_index = {t: idx for idx, t in enumerate(sorted_timestamps)}\n\
-          \        # 获取 abnormal_count 个异常点，按值降序排列\n        abnormal_entries = sorted(chart.items(),\
-          \ key=lambda x: -x[1])[:abnormal_count]\n        \n        growth_rates\
-          \ = []\n        for timestamp, value in abnormal_entries:\n            idx\
-          \ = time_to_index[timestamp]\n            prev_value = None\n          \
-          \  # 向前查找第一个非零值\n            for j in range(idx - 1, -1, -1):\n        \
-          \        prev_val = chart[sorted_timestamps[j]]\n                if prev_val\
-          \ != 0:\n                    prev_value = prev_val\n                   \
-          \ break\n            if prev_value is not None:\n                growth_rate\
-          \ = (value - prev_value) / prev_value\n                growth_rates.append(growth_rate)\n\
-          \        \n        avg_growth = sum(growth_rates) / len(growth_rates) if\
-          \ growth_rates else 0\n        instance[\"abnormal_avg_growth\"] = avg_growth\n\
-          \        \n        del instance['chart']\n    \n    # 按 abnormal_mean 降序取前3\n\
-          \    top_abnormal_means = sorted(data, key=lambda x: x['abnormal_mean'],\
-          \ reverse=True)[:5]\n    # 按 abnormal_avg_growth 降序取前3\n    top_abnormal_growths\
-          \ = sorted(data, key=lambda x: x['abnormal_avg_growth'], reverse=True)[:5]\n\
-          \    \n    return {\n        \"top_abnormal_means\": json.dumps(top_abnormal_means),\n\
-          \        \"top_abnormal_growths\": json.dumps(top_abnormal_growths)\n  \
-          \  }"
-        code_language: python3
-        desc: ''
-        outputs:
-          top_abnormal_growths:
-            children: null
-            type: string
-          top_abnormal_means:
-            children: null
-            type: string
-        selected: false
-        title: RTT异常实例
-        type: code
-        variables:
-        - value_selector:
-          - '17473564454180'
-          - text
-          variable: data_json
-      height: 54
-      id: '1747356923703'
-      position:
-        x: 3363
-        y: 1362
-      positionAbsolute:
-        x: 3363
-        y: 1362
+        x: 3656
+        y: 1236
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -8557,8 +7518,8 @@ workflow:
           completion_params:
             temperature: 0.6
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: cd35fff4-a037-4e72-af99-2ff8299fc5d2
           role: system
@@ -8583,14 +7544,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17473569800940'
       position:
-        x: 3666
-        y: 1252
+        x: 3958
+        y: 1214
       positionAbsolute:
-        x: 3666
-        y: 1252
+        x: 3958
+        y: 1214
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -8604,23 +7565,3061 @@ workflow:
           - '17473569800940'
           - text
           variable: text
+        - value_selector:
+          - '17501667334220'
+          - text
+          variable: alertDirection
         selected: false
         title: 结束
         type: end
-      height: 90
+      height: 116
       id: '1747357345949'
       position:
-        x: 3969
-        y: 1252
+        x: 4567
+        y: 1205
       positionAbsolute:
-        x: 3969
-        y: 1252
+        x: 4567
+        y: 1205
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: a56f2cfc-7dfc-4483-888e-80b4a5eca5c8
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: 10633a48-9249-408a-8a23-63cdc1eaabfc
+          role: user
+          text: "#目的\n根据应用的结论生成根因方向的结论\n如果该方向无异常，level为normal\n#结论数据\n{{#17430596469370.text#}}\n\
+            # 注意\ntype为故障方向\n1网络质量（net），存储问题(storage)，代码性能(code)，依赖慢(downstream)，cpu资源\
+            \ (cpu)\n每个方向直给一个结论即可，不要出现重复\n主要根因方向必须和major结论保持一致，不要不统一\n2且必须给一个有问题的方向(level为major)\n\
+            3 列表必须按照等级排序level从高到低维（major,minor,normal）\n4. 网络质量为net,网络方向问题则为downstream\n\
+            5. cause 中只能填写（网络质量问题，磁盘读写问题，代码性能，下游依赖慢，cpu资源）\n6.reason中的内容必须简洁，xxx出现异常\n\
+            #格式模版\n{\n        \"cause\": \"主要原根因方向\",\n        \"other\": [\n    \
+            \        {\n                \"reason\": \"\",\n                \"type\"\
+            : \"cpu\",\n                \"level\": \"major/minor/normal\"\n      \
+            \      },\n            {\n                \"reason\": \"\",\n        \
+            \        \"type\": \"code\",\n                \"level\": \"minor\"\n \
+            \           },\n            {\n                \"reason\": \"\",\n   \
+            \             \"type\": \"net\",\n                \"level\": \"normal\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"storage\",\n                \"level\": \"\
+            normal\"\n            },\n            {\n                \"reason\": \"\
+            \",\n                \"type\": \"downstream\",\n                \"level\"\
+            : \"normal\"\n            }\n        ]\n    }\n#输出格式\ntype只能为(downstream,\
+            \ storage,net,code,cpu),且每种一个(5种类型需要全部出现)，不要重复，不要有其他内容\njson格式数据，格式参数模版，不要有其他输出"
+        selected: false
+        title: 根因方向JSON
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750068431868'
+      position:
+        x: 13861
+        y: 1146
+      positionAbsolute:
+        x: 13861
+        y: 1146
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: qwen2.5-32b-instruct
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: a56f2cfc-7dfc-4483-888e-80b4a5eca5c8
+          role: system
+          text: 你是一个智能助手，帮助用户解决问题
+        - id: 10633a48-9249-408a-8a23-63cdc1eaabfc
+          role: user
+          text: '#目的
+
+            从故障结论中提取故障方向
+
+            #结论数据
+
+            {{#17473569800940.text#}}
+
+            #输出内容
+
+            故障方向，只输出四个字就好 （如网络方向，cpu方向等）'
+        selected: false
+        title: LLM 6
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 90
+      id: '17501667334220'
+      position:
+        x: 4263
+        y: 1216
+      positionAbsolute:
+        x: 4263
+        y: 1216
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Container id
+            ja_JP: Container id
+            pt_BR: Container id
+            zh_Hans: 容器id
+          label:
+            en_US: containerId
+            ja_JP: containerId
+            pt_BR: containerId
+            zh_Hans: 容器id
+          llm_description: Container id
+          max: null
+          min: null
+          name: containerId
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Node name
+            ja_JP: Node name
+            pt_BR: Node name
+            zh_Hans: 主机名
+          label:
+            en_US: Node name
+            ja_JP: Node name
+            pt_BR: Node name
+            zh_Hans: 主机名
+          llm_description: Node name
+          max: null
+          min: null
+          name: nodeName
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: pid
+            ja_JP: pid
+            pt_BR: pid
+            zh_Hans: pid
+          label:
+            en_US: pid
+            ja_JP: pid
+            pt_BR: pid
+            zh_Hans: pid
+          llm_description: pid
+          max: null
+          min: null
+          name: pid
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: pod
+            ja_JP: pod
+            pt_BR: pod
+            zh_Hans: pod
+          label:
+            en_US: pod
+            ja_JP: pod
+            pt_BR: pod
+            zh_Hans: pod
+          llm_description: pod
+          max: null
+          min: null
+          name: pod
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: cluster
+            ja_JP: cluster
+            pt_BR: cluster
+            zh_Hans: 集群
+          label:
+            en_US: cluster
+            ja_JP: cluster
+            pt_BR: cluster
+            zh_Hans: 集群
+          llm_description: cluster
+          max: null
+          min: null
+          name: cluster
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time(Microsecond)
+            ja_JP: Data query start time(Microsecond)
+            pt_BR: Data query start time(Microsecond)
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time(Microsecond)
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time(Microsecond)
+            ja_JP: Data query end time(Microsecond)
+            pt_BR: Data query end time(Microsecond)
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query end time(Microsecond)
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          cluster: ''
+          containerId: ''
+          endTime: ''
+          nodeName: ''
+          pid: ''
+          pod: ''
+          startTime: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 查询实例所属服务
+        tool_configurations: {}
+        tool_label: 查询实例所属服务
+        tool_name: dataplane_instance_service
+        tool_parameters:
+          containerId:
+            type: mixed
+            value: '{{#1742807803325.containerId#}}'
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          nodeName:
+            type: mixed
+            value: '{{#1742807803325.node#}}'
+          pid:
+            type: mixed
+            value: '{{#1742807803325.pid#}}'
+          pod:
+            type: mixed
+            value: '{{#1742807803325.pod#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+        type: tool
+      height: 54
+      id: '1750657927551'
+      position:
+        x: 938
+        y: 642
+      positionAbsolute:
+        x: 938
+        y: 642
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 服务名
+          label:
+            en_US: service
+            ja_JP: service
+            pt_BR: service
+            zh_Hans: service
+          llm_description: Service name
+          max: null
+          min: null
+          name: service
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: cluster
+            ja_JP: cluster
+            pt_BR: cluster
+            zh_Hans: 集群
+          label:
+            en_US: cluster
+            ja_JP: cluster
+            pt_BR: cluster
+            zh_Hans: cluster
+          llm_description: cluster
+          max: null
+          min: null
+          name: cluster
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time(Microsecond)
+            ja_JP: Data query start time(Microsecond)
+            pt_BR: Data query start time(Microsecond)
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time(Microsecond)
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time(Microsecond)
+            ja_JP: Data query end time(Microsecond)
+            pt_BR: Data query end time(Microsecond)
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query end time(Microsecond)
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          cluster: ''
+          endTime: ''
+          service: ''
+          startTime: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 查询服务实例
+        tool_configurations: {}
+        tool_label: 查询服务实例
+        tool_name: dataplane_service_instances
+        tool_parameters:
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          service:
+            type: mixed
+            value: '{{#1742807803325.service#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+        type: tool
+      height: 54
+      id: '1750657965188'
+      position:
+        x: 938
+        y: 550
+      positionAbsolute:
+        x: 938
+        y: 550
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\ndef main(data: str) -> dict:\n    instances = json.loads(data).get('data',\
+          \ [])\n    return {\n        \"result\": instances,\n    }\n\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: array[object]
+        selected: false
+        title: 提取实例信息
+        type: code
+        variables:
+        - value_selector:
+          - '1750657965188'
+          - text
+          variable: data
+      height: 54
+      id: '1750658087300'
+      position:
+        x: 1240
+        y: 568
+      positionAbsolute:
+        x: 1240
+        y: 568
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\n\ndef main(pod: str, containerId: str, pid: str, node: str, service:\
+          \ str, endpoint: str) -> dict:\n    return {\n        \"result\": [{\n \
+          \           'service': service,\n            'pod': pod,\n            'containerId':\
+          \ containerId,\n            'pid': pid,\n            'node': node,\n   \
+          \         'endpoint': endpoint\n        }],\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: array[object]
+        selected: false
+        title: 统一结构
+        type: code
+        variables:
+        - value_selector:
+          - '1742807803325'
+          - pod
+          variable: pod
+        - value_selector:
+          - '1742807803325'
+          - containerId
+          variable: containerId
+        - value_selector:
+          - '1742807803325'
+          - pid
+          variable: pid
+        - value_selector:
+          - '1742807803325'
+          - node
+          variable: node
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+        - value_selector:
+          - '1742807803325'
+          - endpoint
+          variable: endpoint
+      height: 54
+      id: '1750658174684'
+      position:
+        x: 1240
+        y: 660
+      positionAbsolute:
+        x: 1240
+        y: 660
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: cAdvisor job name
+            ja_JP: cAdvisor job name
+            pt_BR: cAdvisor job name
+            zh_Hans: cAdvisor任务名称
+          label:
+            en_US: cAdvisor job name
+            ja_JP: cAdvisor job name
+            pt_BR: cAdvisor job name
+            zh_Hans: cAdvisor任务名称
+          llm_description: cAdvisor job name
+          max: null
+          min: null
+          name: cadvisor_job_name
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Namespace
+            ja_JP: Namespace
+            pt_BR: Namespace
+            zh_Hans: 命名空间
+          label:
+            en_US: Namespace
+            ja_JP: Namespace
+            pt_BR: Namespace
+            zh_Hans: 命名空间
+          llm_description: Namespace
+          max: null
+          min: null
+          name: namespace
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Pod name
+            ja_JP: Pod name
+            pt_BR: Pod name
+            zh_Hans: Pod名称
+          label:
+            en_US: Pod name
+            ja_JP: Pod name
+            pt_BR: Pod name
+            zh_Hans: Pod名称
+          llm_description: Pod name
+          max: null
+          min: null
+          name: pod
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time(Microsecond)
+            ja_JP: Data query start time(Microsecond)
+            pt_BR: Data query start time(Microsecond)
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time(Microsecond)
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time(Microsecond)
+            ja_JP: Data query end time(Microsecond)
+            pt_BR: Data query end time(Microsecond)
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query end time(Microsecond)
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          cadvisor_job_name: ''
+          endTime: ''
+          namespace: ''
+          pod: ''
+          startTime: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 容器磁盘读取耗时每秒(使用Containerd,按Pod和容器统计)
+        tool_configurations: {}
+        tool_label: 容器磁盘读取耗时每秒(使用Containerd,按Pod和容器统计)
+        tool_name: 容器磁盘读取耗时每秒(使用Containerd,按Pod和容器统计)
+        tool_parameters:
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          namespace:
+            type: mixed
+            value: '{{#17430589567120.namespace#}}'
+          pod:
+            type: mixed
+            value: '{{#17430589567120.pod#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+        type: tool
+      height: 54
+      id: '1750661176423'
+      position:
+        x: 3959
+        y: 696
+      positionAbsolute:
+        x: 3959
+        y: 696
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\ndef main(timestamp: int, reason: str, tags: dict, detail: str, endpoint:\
+          \ str, service: str) -> dict:\n    data = {\n        \"timestamp\": timestamp,\n\
+          \        \"detail\": detail,\n        \"reason\": reason,\n        \"tags\"\
+          : tags,\n    }\n    if service != \"\":\n        data['tags']['service']\
+          \ = service\n    data['tags']['pid'] = str(data['tags']['pid'])\n    data['tags']['pod']\
+          \ = data['tags'].get(\"podName\", \"\")\n    data['tags']['endpoint'] =\
+          \ endpoint\n    return {\n        \"result\": json.dumps(data),\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 告警事件总览
+        type: code
+        variables:
+        - value_selector:
+          - '1741509454645'
+          - first
+          variable: tags
+        - value_selector:
+          - '1741227526517'
+          - endTime
+          variable: timestamp
+        - value_selector:
+          - '1750662088384'
+          - text
+          variable: reason
+        - value_selector:
+          - '1750662084996'
+          - text
+          variable: detail
+        - value_selector:
+          - '1742807803325'
+          - endpoint
+          variable: endpoint
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+      height: 54
+      id: '1750661889002'
+      position:
+        x: 14165
+        y: 904
+      positionAbsolute:
+        x: 14165
+        y: 904
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 8ecc69bb-4504-40cc-9475-d9da1d54e2f8
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: 47fedf0d-54f2-4912-8e87-da9e60b6aa0b
+          role: user
+          text: "#目的\n根据应用的结论生成当前情况的描述\n使用结论内的数据，回答简洁易懂\n#结论数据\n{{#17430596469370.text#}}\n\
+            # 时间\n{{#1741227526517.endTime#}}\n#格式模版参考\n告警报事件结论 \n**事件概述**：\n当前告警事件为XXXX\
+            \ (简洁，不要有其他内容)\n**问题分析**\n初步分析是XXX方向（网络，CPU），不要有其他内容，给出方向即可\n**解决措施**：\n\
+            - 执行XXXX命令（必须和故障方向有关）\n如果网络质量异常，建议消除xxxping值突增的问题\n如果运行队列方向（runq）问题,建议消除程序CPU资源抢占问题。\n\
+            \n#输出格式\n格式参考模版，注意换行和空格，确保文本美观输出，简单易懂(使用MarkDown格式的文本)，且不要有其他输出"
+        selected: false
+        title: 描述
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750662084996'
+      position:
+        x: 13557
+        y: 904
+      positionAbsolute:
+        x: 13557
+        y: 904
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 42284b17-9b6e-4660-aaad-9ba66584a21e
+          role: system
+          text: ''
+        - id: 3d52c2b4-81a0-47d2-bedd-ef62955c057b
+          role: user
+          text: '#目的
+
+            根据应用的结论数据，进一步汇总生成分析过程
+
+            #结论数据
+
+            {{#17430596469370.text#}}
+
+            # 时间
+
+            {{#1741227526517.endTime#}}
+
+            #格式模版参考
+
+            **北极星指标趋势摘要**
+
+            - 按指标维度描述显著变化，
+
+            xxx结论中提取
+
+
+            **方向确定**
+
+            由于xxx数据异常
+
+            因此初步认为是xxx方向
+
+            且xxx数据表名xxx方向正常或影响较小
+
+
+            #输出格式
+
+            注意换行和空格，确保文本美观输出，简单易懂(使用MarkDown格式的文本)，且不要有其他输出'
+        selected: false
+        title: 告警描述格式化文本
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750662088384'
+      position:
+        x: 13861
+        y: 904
+      positionAbsolute:
+        x: 13861
+        y: 904
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\ndef main(alertEventId: str, run_id: str) -> dict:\n    data = {\n\
+          \        \"alertEventId\": alertEventId,\n        \"runId\": run_id\n  \
+          \  }\n    return {\n        \"result\": json.dumps(data),\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 报告标签
+        type: code
+        variables:
+        - value_selector:
+          - '1742807803325'
+          - alertEventId
+          variable: alertEventId
+        - value_selector:
+          - sys
+          - workflow_run_id
+          variable: run_id
+      height: 54
+      id: '1750662168285'
+      position:
+        x: 14165
+        y: 1054
+      positionAbsolute:
+        x: 14165
+        y: 1054
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 9cf805ef-c561-4b9a-a3cd-3e970fc59285
+          role: system
+          text: 你是一个智能助手，帮助用户解决问题
+        - id: 904153b5-a654-458e-9452-23aa907cfa57
+          role: user
+          text: "#目的\n生成建议用户的行动建议\n如执行命令，或者找xxx排除问题\n#结论数据\n{{#17430596469370.text#}}\n\
+            \n\n#格式模版\n{\"suggest\": [\n        {\n            \"action\": \"Add index\
+            \ to payment transaction table.\",\n            \"level\": \"high\"\n\
+            \        },\n        {\n            \"action\": \"Scale up database node\
+            \ CPU resources.\",\n            \"level\": \"medium\"\n        }\n  \
+            \  ] }\n#输出格式\njson格式数据，格式参数模版，不要有其他输出"
+        selected: false
+        title: 可行动建议JSON
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750662408086'
+      position:
+        x: 13861
+        y: 1282
+      positionAbsolute:
+        x: 13861
+        y: 1282
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\ndef main(raw_data: str) -> dict:\n    pattern = r'```json\\\
+          n(.*?)\\n```'\n    match = re.search(pattern, raw_data, re.DOTALL)\n\n \
+          \   json_str = match.group(1)\n    rootcause = json.loads(json_str)\n  \
+          \  return {\n        \"result\": json.dumps(rootcause),\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 提取根因数据
+        type: code
+        variables:
+        - value_selector:
+          - '1750068431868'
+          - text
+          variable: raw_data
+      height: 54
+      id: '1750672701216'
+      position:
+        x: 14165
+        y: 1146
+      positionAbsolute:
+        x: 14165
+        y: 1146
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\ndef main(raw_data: str) -> dict:\n    pattern = r'```json\\\
+          n(.*?)\\n```'\n    match = re.search(pattern, raw_data, re.DOTALL)\n\n \
+          \   json_str = match.group(1)\n    rootcause = json.loads(json_str)\n  \
+          \  return {\n        \"result\": json.dumps(rootcause),\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 提取行动数据
+        type: code
+        variables:
+        - value_selector:
+          - '1750662408086'
+          - text
+          variable: raw_data
+      height: 54
+      id: '17506728633540'
+      position:
+        x: 14165
+        y: 1282
+      positionAbsolute:
+        x: 14165
+        y: 1282
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import requests\nimport json\ndef get_topology(service, cluster, start_time,\
+          \ end_time) -> str:\n        params = {\n          'service': service,\n\
+          \          'cluster': cluster,\n          'startTime': start_time,\n   \
+          \       'endTime': end_time,\n          }\n        resp = requests.get(\"\
+          http://apo-backend-svc:8080\"+ '/api/dataplane/topology', params=params)\n\
+          \        res = {}\n\n\n        query_params = {\n                    'startTime':\
+          \ start_time,\n                    'endTime': end_time,\n              \
+          \      'service': service\n        }\n        response = requests.get(\"\
+          http://apo-backend-svc:8080\"+ '/api/dataplane/redcharts', params=query_params)\n\
+          \        metrics = {}\n        if response.status_code == 200 and response.json()['msg']\
+          \ == '':\n            metrics['latency'] = response.json()['results'][0]['timeseries'][0]['chart']\n\
+          \            metrics['errorRate'] = response.json()['results'][1]['timeseries'][0]['chart']\n\
+          \            metrics['tps'] = response.json()['results'][2]['timeseries'][0]['chart']\n\
+          \        res['current'] = {\n            \"service\": service,\n       \
+          \     \"description\": \"\",\n            \"metrics\": metrics,\n      \
+          \  }\n\n        if resp.status_code == 200 and resp.json()['msg'] == \"\"\
+          :\n            list = resp.json()\n            result = []\n           \
+          \ for item in list['results'] or []:\n                if item[\"name\"]\
+          \ == service:\n                    result = item\n\n            parents\
+          \ = []\n            for p_svc in result['parents']:\n                query_params\
+          \ = {\n                    'startTime': start_time,\n                  \
+          \  'endTime': end_time,\n                    'service': p_svc\n        \
+          \        }\n                response = requests.get(\"http://apo-backend-svc:8080\"\
+          + '/api/dataplane/redcharts', params=query_params)\n                if response.status_code\
+          \ != 200 or response.json()['msg'] != '':\n                    continue\n\
+          \                metrics = {}\n                metrics['latency'] = response.json()['results'][0]['timeseries'][0]['chart']\n\
+          \                metrics['errorRate'] = response.json()['results'][1]['timeseries'][0]['chart']\n\
+          \                metrics['tps'] = response.json()['results'][2]['timeseries'][0]['chart']\n\
+          \                parents.append({\n                    'service': p_svc,\n\
+          \                    'description': \"\",\n                    'metrics':\
+          \ metrics,\n                })\n            \n            children = []\n\
+          \            for c_svc in result['children']:\n                query_params\
+          \ = {\n                    'startTime': start_time,\n                  \
+          \  'endTime': end_time,\n                    'service': c_svc\n        \
+          \        }\n                response = requests.get(\"http://apo-backend-svc:8080\"\
+          + '/api/dataplane/redcharts', params=query_params)\n                if response.status_code\
+          \ != 200 or response.json()['msg'] != '':\n                    continue\n\
+          \                metrics = {}\n                metrics['latency'] = response.json()['results'][0]['timeseries'][0]['chart']\n\
+          \                metrics['errorRate'] = response.json()['results'][1]['timeseries'][0]['chart']\n\
+          \                metrics['tps'] = response.json()['results'][2]['timeseries'][0]['chart']\n\
+          \                children.append({\n                    'service': c_svc,\n\
+          \                    'description': \"\",\n                    'metrics':\
+          \ metrics,\n                })\n            \n            res['children']\
+          \ = children\n            res['parents'] = parents\n            return json.dumps(res)\n\
+          \n\ndef main(service: str, startTime: int, endTime: int) -> dict:\n    rc\
+          \ = get_topology(service, \"\", startTime, endTime)\n    if rc == None:\n\
+          \        rc = \"{}\"\n    return {\n        \"result\": rc,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 获取拓扑
+        type: code
+        variables:
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+        - value_selector:
+          - '1741227526517'
+          - startTime
+          variable: startTime
+        - value_selector:
+          - '1741227526517'
+          - endTime
+          variable: endTime
+      height: 54
+      id: '1750750056742'
+      position:
+        x: 14165
+        y: 1374
+      positionAbsolute:
+        x: 14165
+        y: 1374
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: reportType
+            zh_Hans: 报告类型
+          label:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: reportType
+            zh_Hans: 报告类型
+          llm_description: alert report type
+          max: null
+          min: null
+          name: reportType
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: tags
+            zh_Hans: 报告标签（用于检索）
+          label:
+            en_US: tags
+            ja_JP: tags
+            pt_BR: tags
+            zh_Hans: 报告标签（用于检索）
+          llm_description: alert report tags
+          max: null
+          min: null
+          name: tags
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: overview
+            ja_JP: overview
+            pt_BR: overview
+            zh_Hans: 告警事件总览
+          label:
+            en_US: overview
+            ja_JP: overview
+            pt_BR: overview
+            zh_Hans: 告警事件总览
+          llm_description: overview
+          max: null
+          min: null
+          name: overview
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: topology
+            ja_JP: topology
+            pt_BR: topology
+            zh_Hans: 报告类型
+          label:
+            en_US: topology
+            ja_JP: topology
+            pt_BR: topology
+            zh_Hans: 拓扑数据
+          llm_description: topology data
+          max: null
+          min: null
+          name: topology
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: rootCauseAnalysis
+            ja_JP: rootCauseAnalysis
+            pt_BR: rootCauseAnalysis
+            zh_Hans: 根因分析结论
+          label:
+            en_US: rootCauseAnalysis
+            ja_JP: rootCauseAnalysis
+            pt_BR: rootCauseAnalysis
+            zh_Hans: 根因分析结论
+          llm_description: rootCauseAnalysis
+          max: null
+          min: null
+          name: rootCauseAnalysis
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: suggest
+            ja_JP: suggest
+            pt_BR: suggest
+            zh_Hans: 可行动方向建议
+          label:
+            en_US: suggest
+            ja_JP: suggest
+            pt_BR: suggest
+            zh_Hans: 可行动方向建议
+          llm_description: suggest
+          max: null
+          min: null
+          name: suggest
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: evidence
+            ja_JP: evidence
+            pt_BR: evidence
+            zh_Hans: 根因分析结论
+          label:
+            en_US: evidence
+            ja_JP: evidence
+            pt_BR: evidence
+            zh_Hans: 验证数据
+          llm_description: evidence
+          max: null
+          min: null
+          name: evidence
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        params:
+          evidence: ''
+          overview: ''
+          reportType: ''
+          rootCauseAnalysis: ''
+          suggest: ''
+          tags: ''
+          topology: ''
+        provider_id: apo_analysis
+        provider_name: apo_analysis
+        provider_type: builtin
+        selected: false
+        title: 生成告警分析报告
+        tool_configurations: {}
+        tool_label: 生成告警分析报告
+        tool_name: Generate alert analysis report
+        tool_parameters:
+          evidence:
+            type: mixed
+            value: '{{#1750769951427.result#}}'
+          overview:
+            type: mixed
+            value: '{{#1750661889002.result#}}'
+          reportType:
+            type: mixed
+            value: slow
+          rootCauseAnalysis:
+            type: mixed
+            value: '{{#1750672701216.result#}}'
+          suggest:
+            type: mixed
+            value: '{{#17506728633540.result#}}'
+          tags:
+            type: mixed
+            value: '{{#1750662168285.result#}}'
+          topology:
+            type: mixed
+            value: '{{#1750750056742.result#}}'
+        type: tool
+      height: 54
+      id: '1750754610625'
+      position:
+        x: 14467
+        y: 1146
+      positionAbsolute:
+        x: 14467
+        y: 1146
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\ndef main(arg1: str, red: str, logs: str, red_text: str, rtt_text:\
+          \ str, log_text: str) -> dict:\n    rtt = json.loads(arg1)\n    logs_raw\
+          \ = json.loads(logs)\n    metrics = {\n      \"type\": \"metrics\",\n  \
+          \    \"name\": \"应用网络质量指标\",\n      \"description\": rtt_text,\n      \"\
+          unit\": \"s\",\n    }\n    data = []\n    label_set = []\n    for metric\
+          \ in rtt['data']['timeseries'] or []:\n        if metric['legend'] not in\
+          \ label_set:\n            data.append(metric)\n            label_set.append(metric['legend'])\n\
+          \n    metrics['data'] = data\n    logs_data = {\n        \"type\": \"log\"\
+          ,\n        \"name\": \"应用日志\",\n        \"description\": log_text,\n   \
+          \     \"data\": logs_raw.get(\"logs\", [])\n    }\n    red_data = json.loads(red)\n\
+          \    red_data[\"description\"] = red_text\n\n    return {\n        \"result\"\
+          : json.dumps({\n            \"evidence\": [logs_data, red_data, metrics]\n\
+          \        }),\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 生成验证数据
+        type: code
+        variables:
+        - value_selector:
+          - '17430598942980'
+          - text
+          variable: arg1
+        - value_selector:
+          - '1750819000832'
+          - result
+          variable: red
+        - value_selector:
+          - '1750830805330'
+          - logs
+          variable: logs
+        - value_selector:
+          - '1750927458985'
+          - text
+          variable: red_text
+        - value_selector:
+          - '1750927416010'
+          - text
+          variable: rtt_text
+        - value_selector:
+          - '1750927215923'
+          - text
+          variable: log_text
+      height: 54
+      id: '1750769951427'
+      position:
+        x: 14165
+        y: 1588
+      positionAbsolute:
+        x: 14165
+        y: 1588
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import requests\nimport json\n\n\ndef get_red(service, cluster, start_time,\
+          \ end_time) -> str:\n    query_params = {\"startTime\": start_time, \"endTime\"\
+          : end_time, \"service\": service}\n    response = requests.get(\n      \
+          \  \"http://apo-backend-svc:8080\" + \"/api/dataplane/redcharts\", params=query_params\n\
+          \    )\n    data = []\n    if response.status_code == 200 and response.json()[\"\
+          msg\"] == \"\":\n        la = response.json()[\"results\"][0][\"timeseries\"\
+          ][0]\n        data.append(\n            {\n                \"type\": \"\
+          latency\",\n                \"name\": la[\"legend\"],\n                \"\
+          unit\": \"ms\",\n                \"chartData\": la[\"chart\"][\"chartData\"\
+          ],\n            }\n        )\n        er = response.json()[\"results\"][1][\"\
+          timeseries\"][0]\n        data.append(\n            {\n                \"\
+          type\": \"errorRate\",\n                \"name\": er[\"legend\"],\n    \
+          \            \"unit\": \"percent\",\n                \"chartData\": er[\"\
+          chart\"][\"chartData\"],\n            }\n        )\n        tps = response.json()[\"\
+          results\"][2][\"timeseries\"][0]\n        data.append(\n            {\n\
+          \                \"type\": \"tps\",\n                \"name\": tps[\"legend\"\
+          ],\n                \"unit\": \"tps\",\n                \"chartData\": tps[\"\
+          chart\"][\"chartData\"],\n            }\n        )\n        print(data)\n\
+          \        return data\n    else:\n        return data\n\n\ndef main(service:\
+          \ str, startTime: int, endTime: int) -> dict:\n    rc = get_red(service,\
+          \ \"\", startTime, endTime)\n    if rc is None:\n        rc = \"{}\"\n \
+          \   return {\n        \"result\": json.dumps({\n            \"name\": \"\
+          服务监控指标\",\n            \"type\": \"red\",\n            \"data\": rc\n  \
+          \      })\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 获取red指标
+        type: code
+        variables:
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+        - value_selector:
+          - '1741227526517'
+          - startTime
+          variable: startTime
+        - value_selector:
+          - '1741227526517'
+          - endTime
+          variable: endTime
+      height: 54
+      id: '1750819000832'
+      position:
+        x: 13558
+        y: 1746
+      positionAbsolute:
+        x: 13558
+        y: 1746
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\ndef main(pod: str, service: str, node: str, pid: str, containerId:\
+          \ str) -> dict:\n    query = ''\n    if len(containerId) > 0 and len(node)\
+          \ > 0:\n        query = f\"\"\"container_id='{containerId}' and host_name='{node}'\"\
+          \"\"\n    elif len(pod) > 0 and len(service) > 0:\n        query = f\"\"\
+          \"k8s_pod_name='{pod}' and container_name='{service}'\"\"\"\n    elif len(pod)\
+          \ > 0:\n        query = f\"\"\"k8s_pod_name='{pod}'\"\"\"\n    elif len(node)\
+          \ > 0 and len(pid) > 0:\n        query = f\"\"\"host_name='{node}' and pid='{pid}'\"\
+          \"\"\n    elif len(service) > 0:\n        query = f\"\"\"container_name='{service}'\"\
+          \"\"\n    elif len(containerId) > 0:\n        query = f\"\"\"container_id='{containerId}'\"\
+          \"\"\n    elif len(node) > 0:\n        query = f\"\"\"host_name='{node}'\"\
+          \"\"\n\n            \n    return {\n        \"query\": query,\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          query:
+            children: null
+            type: string
+        selected: false
+        title: 获取日志查询条件
+        type: code
+        variables:
+        - value_selector:
+          - '17430589567120'
+          - pod
+          variable: pod
+        - value_selector:
+          - '1742807803325'
+          - service
+          variable: service
+        - value_selector:
+          - '17430589567120'
+          - node
+          variable: node
+        - value_selector:
+          - '17430589567120'
+          - pid
+          variable: pid
+        - value_selector:
+          - '1742807803325'
+          - containerId
+          variable: containerId
+      height: 54
+      id: '1750830567613'
+      position:
+        x: 12650
+        y: 1471
+      positionAbsolute:
+        x: 12650
+        y: 1471
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Query condition(clickhouse where clause).
+            ja_JP: Query condition(clickhouse where clause).
+            pt_BR: Query condition(clickhouse where clause).
+            zh_Hans: 查询条件（clickhouse where子句）
+          label:
+            en_US: Query condition(clickhouse where clause).
+            ja_JP: Query condition(clickhouse where clause).
+            pt_BR: Query condition(clickhouse where clause).
+            zh_Hans: 查询条件（clickhouse where子句）
+          llm_description: Query condition(clickhouse where clause).
+          max: null
+          min: null
+          name: query
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Current page
+            ja_JP: Current page
+            pt_BR: Current page
+            zh_Hans: 当前页
+          label:
+            en_US: Current page
+            ja_JP: Current page
+            pt_BR: Current page
+            zh_Hans: 当前页
+          llm_description: Current page
+          max: null
+          min: null
+          name: pageNum
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Page size
+            ja_JP: Page size
+            pt_BR: Page size
+            zh_Hans: 页大小
+          label:
+            en_US: Page size
+            ja_JP: Page size
+            pt_BR: Page size
+            zh_Hans: 页大小
+          llm_description: Page size
+          max: null
+          min: null
+          name: pageSize
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Start timestamp in microseconds
+            ja_JP: Start timestamp in microseconds
+            pt_BR: Start timestamp in microseconds
+            zh_Hans: 查询开始时间（微秒）
+          label:
+            en_US: Start Time
+            ja_JP: Start Time
+            pt_BR: Start Time
+            zh_Hans: 开始时间
+          llm_description: Microsecond timestamp for start time
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: End timestamp in microseconds
+            ja_JP: End timestamp in microseconds
+            pt_BR: End timestamp in microseconds
+            zh_Hans: 查询结束时间（微秒）
+          label:
+            en_US: End Time
+            ja_JP: End Time
+            pt_BR: End Time
+            zh_Hans: 结束时间
+          llm_description: Microsecond timestamp for end time
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          endTime: ''
+          pageNum: ''
+          pageSize: ''
+          query: ''
+          startTime: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 查询全量日志
+        tool_configurations: {}
+        tool_label: 查询全量日志
+        tool_name: 查询全量日志
+        tool_parameters:
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          pageNum:
+            type: constant
+            value: 1
+          pageSize:
+            type: constant
+            value: 999
+          query:
+            type: mixed
+            value: '{{#1750830567613.query#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+        type: tool
+      height: 54
+      id: '1750830747193'
+      position:
+        x: 12953
+        y: 1452
+      positionAbsolute:
+        x: 12953
+        y: 1452
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\nfrom typing import List\nimport json\n\nERROR_PATTERNS:\
+          \ List[str] = [\n    r\"ERROR\",\n    r\"ERR\",\n    r\"EXCEPTION\",\n \
+          \   r\"PANIC\",\n    r\"FAIL(?:ED)?\",\n    r\"WRONG\",\n    r\"FATAL\"\
+          ,\n    r\"500\",\n    r\"5\\d{2}\",\n]\n\nERROR_REGEXES = [re.compile(pat,\
+          \ re.IGNORECASE) for pat in ERROR_PATTERNS]\n\ndef is_error_log(line: str)\
+          \ -> bool:\n    if not isinstance(line, (str, bytes)):\n        return False\n\
+          \    for regex in ERROR_REGEXES:\n        if regex.search(line):\n     \
+          \       return True\n    return False\n\ndef main(data_json: str) -> dict:\n\
+          \    logs = json.loads(data_json).get(\"data\", {}).get(\"logContents\"\
+          , {}).get(\"contents\", [])\n    \n    error_logs = []\n    all_logs = []\n\
+          \    \n    for log in logs or []:\n        content = log.get(\"body\", \"\
+          \")\n        timestamp = log.get(\"timestamp\")\n        tags = log.get('tags',\
+          \ {})\n        \n        simplified_log = {\n            \"body\": content,\n\
+          \            \"timestamp\": timestamp,\n            \"tags\": tags\n   \
+          \     }\n        \n        all_logs.append(simplified_log)\n        if is_error_log(content):\n\
+          \            error_logs.append(simplified_log)\n    \n    result_logs =\
+          \ error_logs if error_logs else all_logs[:100]\n    \n    MAX_LENGTH = 50000\n\
+          \    result_logs_str = json.dumps({\"logs\": result_logs}, separators=(\"\
+          ,\", \":\"))\n    \n    while len(result_logs_str) > MAX_LENGTH and len(result_logs)\
+          \ > 0:\n        remove_count = max(1, len(result_logs) // 10)\n        result_logs\
+          \ = result_logs[:-remove_count]\n        result_logs_str = json.dumps({\"\
+          logs\": result_logs}, separators=(\",\", \":\"))\n    \n    return {\"logs\"\
+          : result_logs_str}"
+        code_language: python3
+        desc: ''
+        outputs:
+          logs:
+            children: null
+            type: string
+        selected: false
+        title: 提取错误日志
+        type: code
+        variables:
+        - value_selector:
+          - '1750830747193'
+          - text
+          variable: data_json
+      height: 54
+      id: '1750830805330'
+      position:
+        x: 13255
+        y: 1452
+      positionAbsolute:
+        x: 13255
+        y: 1452
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: eb2032a5-ca17-48b4-b532-1c45ed948e91
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: 5b7f74ed-32ec-4351-a51d-74a723bad9a8
+          role: user
+          text: '# 目的
+
+            输出当前日志数据的情况，输出字数100左右，尽量简洁名了
+
+            # 日志数据
+
+            {{#1750830805330.logs#}}
+
+            #输出
+
+            从日志中可以看出xxxx'
+        selected: false
+        title: 日志总结
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750927215923'
+      position:
+        x: 13861
+        y: 1452
+      positionAbsolute:
+        x: 13861
+        y: 1452
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 40620e63-f76d-4e8b-bd1d-5397dfa824ae
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: b7859471-5c89-4e79-be39-dc42df906ce5
+          role: user
+          text: '# 目的
+
+            输出当前网络质量数据（RTT）的情况，判断是否大量异常(超过0.05s或者0.2s)输出字数100左右，尽量简洁名了
+
+            # 网络质量数据
+
+            {{#17430598942980.text#}}
+
+            #输出
+
+            从图表中可以看出网络质量xxx'
+        selected: false
+        title: 网络质量总结
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750927416010'
+      position:
+        x: 13861
+        y: 1588
+      positionAbsolute:
+        x: 13861
+        y: 1588
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 0d6f5be7-b8d0-4354-ae42-7ad580e19039
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: e090acfc-76e6-47e7-8296-465513ee7c4b
+          role: user
+          text: '# 目的
+
+            输出当前应用RED指标数据（tps,延时，错误率）的情况（升高还是下降），输出字数100左右，尽量简洁名了
+
+            # RED指标数据
+
+            {{#1750819000832.result#}}
+
+            #输出
+
+            从图表中可以看出xxxx'
+        selected: false
+        title: 应用RED指标总结
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750927458985'
+      position:
+        x: 13861
+        y: 1724
+      positionAbsolute:
+        x: 13861
+        y: 1724
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: bf855196-6899-4b0c-a363-404c077ba96f
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: 0ee4016d-1cbb-4dbb-89de-2d76f3caeebc
+          role: user
+          text: '#目的
+
+            从故障结论中提取故障方向
+
+            # 注意
+
+            根据结论的内容划分故障方向
+
+            1 如果网络链路rtt正常，网络方向给出下游依赖问题
+
+            #结论数据
+
+            {{#17430596469370.text#}}
+
+            #输出内容
+
+            故障方向，只输出四个字就好 （如网络方向，下游依赖问题，cpu方向等）'
+        selected: false
+        title: LLM 13
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750995139153'
+      position:
+        x: 15073
+        y: 1146
+      positionAbsolute:
+        x: 15073
+        y: 1146
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import json\n\n\ndef _get_avg(values):\n    if not values:\n      \
+          \  return 0\n    return sum(values) / len(values)\n\ndef _get_standard_deviation(avg,\
+          \ values):\n    if len(values) == 0:\n        return 0\n    squared_diffs\
+          \ = [(x - avg)**2 for x in values]\n    sum_squared_diffs = sum(squared_diffs)\n\
+          \    variance = sum_squared_diffs / (len(values))\n    return variance**0.5\n\
+          \ndef analyze_data(result_str: str):        \n\n        data = json.loads(result_str)\n\
+          \        timeseries = data.get('data', {}).get('timeseries', [])\n     \
+          \   unit = data.get('unit', '')\n        filtered = []\n\n        for entry\
+          \ in timeseries:\n            labels = entry.get('labels', {})\n\n     \
+          \       chart = entry.get('chart', {}).get('chartData', {})\n          \
+          \  values = [v for v in chart.values() if v != 0]\n\n            if len(values)\
+          \ == 0:\n                continue\n\n            avg = _get_avg(values)\n\
+          \            variance = _get_standard_deviation(avg, values)\n\n       \
+          \     threshold = avg + 1 * variance\n            \n            count =\
+          \ 0\n            for _, value in chart.items():\n                if value\
+          \ > threshold:\n                    count += 1\n\n            if count !=\
+          \ 0:\n                res = {\n                    \"chart\": chart,\n \
+          \                   \"abnormalCount\": count,\n                    \"labels\"\
+          : labels,\n                    \"avg\": avg,\n                    \"unit\"\
+          : unit\n                }\n                filtered.append(res)\n      \
+          \          \n\n        return json.dumps(filtered)\n    \ndef main(arg1:\
+          \ str) -> dict:\n    res = analyze_data(arg1)\n    return {\n        \"\
+          result\": res,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: file异常指标
+        type: code
+        variables:
+        - value_selector:
+          - '17430597987060'
+          - text
+          variable: arg1
+      height: 54
+      id: '1751112705936'
+      position:
+        x: 4262
+        y: 696
+      positionAbsolute:
+        x: 4262
+        y: 696
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import json\n\n\ndef _get_avg(values):\n    if not values:\n      \
+          \  return 0\n    return sum(values) / len(values)\n\ndef _get_standard_deviation(avg,\
+          \ values):\n    if len(values) == 0:\n        return 0\n    squared_diffs\
+          \ = [(x - avg)**2 for x in values]\n    sum_squared_diffs = sum(squared_diffs)\n\
+          \    variance = sum_squared_diffs / (len(values))\n    return variance**0.5\n\
+          \ndef analyze_data(result_str: str):        \n\n        data = json.loads(result_str)\n\
+          \        timeseries = data.get('data', {}).get('timeseries', [])\n     \
+          \   unit = data.get('unit', '')\n        filtered = []\n\n        for entry\
+          \ in timeseries:\n            labels = entry.get('labels', {})\n\n     \
+          \       chart = entry.get('chart', {}).get('chartData', {})\n          \
+          \  values = [v for v in chart.values() if v != 0]\n\n            if len(values)\
+          \ == 0:\n                continue\n\n            avg = _get_avg(values)\n\
+          \            variance = _get_standard_deviation(avg, values)\n\n       \
+          \     threshold = avg + 1 * variance\n            \n            count =\
+          \ 0\n            for _, value in chart.items():\n                if value\
+          \ > threshold:\n                    count += 1\n\n            if count !=\
+          \ 0:\n                res = {\n                    \"chart\": chart,\n \
+          \                   \"abnormalCount\": count,\n                    \"labels\"\
+          : labels,\n                    \"avg\": avg,\n                    \"unit\"\
+          : unit\n                }\n                filtered.append(res)\n      \
+          \          \n\n        return json.dumps(filtered)\n    \ndef main(arg1:\
+          \ str) -> dict:\n    res = analyze_data(arg1)\n    return {\n        \"\
+          result\": res,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: epoll异常指标
+        type: code
+        variables:
+        - value_selector:
+          - '17430610599980'
+          - text
+          variable: arg1
+      height: 54
+      id: '17511127594560'
+      position:
+        x: 4262
+        y: 790
+      positionAbsolute:
+        x: 4262
+        y: 790
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import json\n\n\ndef _get_avg(values):\n    if not values:\n      \
+          \  return 0\n    return sum(values) / len(values)\n\ndef _get_standard_deviation(avg,\
+          \ values):\n    if len(values) == 0:\n        return 0\n    squared_diffs\
+          \ = [(x - avg)**2 for x in values]\n    sum_squared_diffs = sum(squared_diffs)\n\
+          \    variance = sum_squared_diffs / (len(values))\n    return variance**0.5\n\
+          \ndef analyze_data(result_str: str):        \n\n        data = json.loads(result_str)\n\
+          \        timeseries = data.get('data', {}).get('timeseries', [])\n     \
+          \   unit = data.get('unit', '')\n        filtered = []\n\n        for entry\
+          \ in timeseries:\n            labels = entry.get('labels', {})\n\n     \
+          \       chart = entry.get('chart', {}).get('chartData', {})\n          \
+          \  values = [v for v in chart.values() if v != 0]\n\n            if len(values)\
+          \ == 0:\n                continue\n\n            avg = _get_avg(values)\n\
+          \            variance = _get_standard_deviation(avg, values)\n\n       \
+          \     threshold = avg + 1 * variance\n            \n            count =\
+          \ 0\n            for _, value in chart.items():\n                if value\
+          \ > threshold:\n                    count += 1\n\n            if count !=\
+          \ 0:\n                res = {\n                    \"chart\": chart,\n \
+          \                   \"abnormalCount\": count,\n                    \"labels\"\
+          : labels,\n                    \"avg\": avg,\n                    \"unit\"\
+          : unit\n                }\n                filtered.append(res)\n      \
+          \          \n\n        return json.dumps(filtered)\n    \ndef main(arg1:\
+          \ str) -> dict:\n    res = analyze_data(arg1)\n    return {\n        \"\
+          result\": res,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: cpu异常指标
+        type: code
+        variables:
+        - value_selector:
+          - '17430595109950'
+          - text
+          variable: arg1
+      height: 54
+      id: '17511128355920'
+      position:
+        x: 3958
+        y: 1018
+      positionAbsolute:
+        x: 3958
+        y: 1018
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import json\n\n\ndef _get_avg(values):\n    if not values:\n      \
+          \  return 0\n    return sum(values) / len(values)\n\ndef _get_standard_deviation(avg,\
+          \ values):\n    if len(values) == 0:\n        return 0\n    squared_diffs\
+          \ = [(x - avg)**2 for x in values]\n    sum_squared_diffs = sum(squared_diffs)\n\
+          \    variance = sum_squared_diffs / (len(values))\n    return variance**0.5\n\
+          \ndef analyze_data(result_str: str):        \n\n        data = json.loads(result_str)\n\
+          \        timeseries = data.get('data', {}).get('timeseries', [])\n     \
+          \   unit = data.get('unit', '')\n        filtered = []\n\n        for entry\
+          \ in timeseries:\n            labels = entry.get('labels', {})\n\n     \
+          \       chart = entry.get('chart', {}).get('chartData', {})\n          \
+          \  values = [v for v in chart.values() if v != 0]\n\n            if len(values)\
+          \ == 0:\n                continue\n\n            avg = _get_avg(values)\n\
+          \            variance = _get_standard_deviation(avg, values)\n\n       \
+          \     threshold = avg + 1 * variance\n            \n            count =\
+          \ 0\n            for _, value in chart.items():\n                if value\
+          \ > threshold:\n                    count += 1\n\n            if count !=\
+          \ 0:\n                res = {\n                    \"chart\": chart,\n \
+          \                   \"abnormalCount\": count,\n                    \"labels\"\
+          : labels,\n                    \"avg\": avg,\n                    \"unit\"\
+          : unit\n                }\n                filtered.append(res)\n      \
+          \          \n\n        return json.dumps(filtered)\n    \ndef main(arg1:\
+          \ str) -> dict:\n    res = analyze_data(arg1)\n    return {\n        \"\
+          result\": res,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: net异常指标
+        type: code
+        variables:
+        - value_selector:
+          - '17430598907140'
+          - text
+          variable: arg1
+      height: 54
+      id: '17511128736240'
+      position:
+        x: 3958
+        y: 1112
+      positionAbsolute:
+        x: 3958
+        y: 1112
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import json\n\n\ndef _get_avg(values):\n    if not values:\n      \
+          \  return 0\n    return sum(values) / len(values)\n\ndef _get_standard_deviation(avg,\
+          \ values):\n    if len(values) == 0:\n        return 0\n    squared_diffs\
+          \ = [(x - avg)**2 for x in values]\n    sum_squared_diffs = sum(squared_diffs)\n\
+          \    variance = sum_squared_diffs / (len(values))\n    return variance**0.5\n\
+          \ndef analyze_data(result_str: str):        \n\n        data = json.loads(result_str)\n\
+          \        timeseries = data.get('data', {}).get('timeseries', [])\n     \
+          \   unit = data.get('unit', '')\n        filtered = []\n\n        for entry\
+          \ in timeseries:\n            labels = entry.get('labels', {})\n\n     \
+          \       chart = entry.get('chart', {}).get('chartData', {})\n          \
+          \  values = [v for v in chart.values() if v != 0]\n\n            if len(values)\
+          \ == 0:\n                continue\n\n            avg = _get_avg(values)\n\
+          \            variance = _get_standard_deviation(avg, values)\n\n       \
+          \     threshold = avg + 1 * variance\n            \n            count =\
+          \ 0\n            for _, value in chart.items():\n                if value\
+          \ > threshold:\n                    count += 1\n\n            if count !=\
+          \ 0:\n                res = {\n                    \"chart\": chart,\n \
+          \                   \"abnormalCount\": count,\n                    \"labels\"\
+          : labels,\n                    \"avg\": avg,\n                    \"unit\"\
+          : unit\n                }\n                filtered.append(res)\n      \
+          \          \n\n        return json.dumps(filtered)\n    \ndef main(arg1:\
+          \ str) -> dict:\n    res = analyze_data(arg1)\n    return {\n        \"\
+          result\": res,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: runq异常指标
+        type: code
+        variables:
+        - value_selector:
+          - '17430610719970'
+          - text
+          variable: arg1
+      height: 54
+      id: '17511129103380'
+      position:
+        x: 3958
+        y: 1358
+      positionAbsolute:
+        x: 3958
+        y: 1358
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 40620e63-f76d-4e8b-bd1d-5397dfa824ae
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: b7859471-5c89-4e79-be39-dc42df906ce5
+          role: user
+          text: '# 目的
+
+            输出当前网络质量数据（RTT）的情况，判断是否大量异常(超过0.05s或者0.2s)输出字数100左右，尽量简洁名了
+
+            # 网络质量数据
+
+            {{#17515143872690.result#}}
+
+            # 注意
+
+            必须要持续出现大量异常点位，才认为网络质量出现问题，否则还是认为状态良好
+
+            如果RTT数据为空，认为网络质量数据正常
+
+            #输出
+
+            从图表中可以看出网络质量xxx'
+        selected: false
+        title: 网络Ping
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '17511674060740'
+      position:
+        x: 4870
+        y: 882
+      positionAbsolute:
+        x: 4870
+        y: 882
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 业务服务名称
+          label:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 业务服务名称
+          llm_description: Service name
+          max: null
+          min: null
+          name: service
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: endpoint
+            ja_JP: endpoint
+            pt_BR: endpoint
+            zh_Hans: 业务服务端点
+          label:
+            en_US: endpoint
+            ja_JP: endpoint
+            pt_BR: endpoint
+            zh_Hans: 业务服务端点
+          llm_description: endpoint
+          max: null
+          min: null
+          name: endpoint
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Type (cpu,net,file,runq)
+            ja_JP: Type (cpu,net,file,runq)
+            pt_BR: Type (cpu,net,file,runq)
+            zh_Hans: 报告类型(cpu,net,file,runq)
+          label:
+            en_US: Type (cpu,net,file,runq)
+            ja_JP: Type (cpu,net,file,runq)
+            pt_BR: Type (cpu,net,file,runq)
+            zh_Hans: 报告类型(cpu,net,file,runq)
+          llm_description: Type (cpu,net,file,runq)
+          max: null
+          min: null
+          name: type
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time(Microsecond)
+            ja_JP: Data query start time(Microsecond)
+            pt_BR: Data query start time
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time(Microsecond)
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time(Microsecond)
+            ja_JP: Data query end time(Microsecond)
+            pt_BR: Data query end time(Microsecond)
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query end time(Microsecond)
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          endTime: ''
+          endpoint: ''
+          service: ''
+          startTime: ''
+          type: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 查询服务CPU方向根因报告
+        tool_configurations: {}
+        tool_label: 查询服务根因报告
+        tool_name: 查询服务根因报告
+        tool_parameters:
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          endpoint:
+            type: mixed
+            value: '{{#1742807803325.endpoint#}}'
+          service:
+            type: mixed
+            value: '{{#1742807803325.service#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+          type:
+            type: mixed
+            value: cpu_time
+        type: tool
+      height: 54
+      id: '1751504789699'
+      position:
+        x: 4870
+        y: 1018
+      positionAbsolute:
+        x: 4870
+        y: 1018
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 业务服务名称
+          label:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 业务服务名称
+          llm_description: Service name
+          max: null
+          min: null
+          name: service
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: endpoint
+            ja_JP: endpoint
+            pt_BR: endpoint
+            zh_Hans: 业务服务端点
+          label:
+            en_US: endpoint
+            ja_JP: endpoint
+            pt_BR: endpoint
+            zh_Hans: 业务服务端点
+          llm_description: endpoint
+          max: null
+          min: null
+          name: endpoint
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Type (cpu,net,file,runq)
+            ja_JP: Type (cpu,net,file,runq)
+            pt_BR: Type (cpu,net,file,runq)
+            zh_Hans: 报告类型(cpu,net,file,runq)
+          label:
+            en_US: Type (cpu,net,file,runq)
+            ja_JP: Type (cpu,net,file,runq)
+            pt_BR: Type (cpu,net,file,runq)
+            zh_Hans: 报告类型(cpu,net,file,runq)
+          llm_description: Type (cpu,net,file,runq)
+          max: null
+          min: null
+          name: type
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time(Microsecond)
+            ja_JP: Data query start time(Microsecond)
+            pt_BR: Data query start time
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time(Microsecond)
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time(Microsecond)
+            ja_JP: Data query end time(Microsecond)
+            pt_BR: Data query end time(Microsecond)
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query end time(Microsecond)
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          endTime: ''
+          endpoint: ''
+          service: ''
+          startTime: ''
+          type: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 查询服务Net方向根因报告
+        tool_configurations: {}
+        tool_label: 查询服务根因报告
+        tool_name: 查询服务根因报告
+        tool_parameters:
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          endpoint:
+            type: mixed
+            value: '{{#1742807803325.endpoint#}}'
+          service:
+            type: mixed
+            value: '{{#1742807803325.service#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+          type:
+            type: mixed
+            value: network_time
+        type: tool
+      height: 54
+      id: '17515048509810'
+      position:
+        x: 4870
+        y: 1112
+      positionAbsolute:
+        x: 4870
+        y: 1112
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 业务服务名称
+          label:
+            en_US: Service name
+            ja_JP: Service name
+            pt_BR: Service name
+            zh_Hans: 业务服务名称
+          llm_description: Service name
+          max: null
+          min: null
+          name: service
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: endpoint
+            ja_JP: endpoint
+            pt_BR: endpoint
+            zh_Hans: 业务服务端点
+          label:
+            en_US: endpoint
+            ja_JP: endpoint
+            pt_BR: endpoint
+            zh_Hans: 业务服务端点
+          llm_description: endpoint
+          max: null
+          min: null
+          name: endpoint
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Type (cpu,net,file,runq)
+            ja_JP: Type (cpu,net,file,runq)
+            pt_BR: Type (cpu,net,file,runq)
+            zh_Hans: 报告类型(cpu,net,file,runq)
+          label:
+            en_US: Type (cpu,net,file,runq)
+            ja_JP: Type (cpu,net,file,runq)
+            pt_BR: Type (cpu,net,file,runq)
+            zh_Hans: 报告类型(cpu,net,file,runq)
+          llm_description: Type (cpu,net,file,runq)
+          max: null
+          min: null
+          name: type
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query start time(Microsecond)
+            ja_JP: Data query start time(Microsecond)
+            pt_BR: Data query start time
+            zh_Hans: 开始时间 (微秒)
+          label:
+            en_US: startTime
+            ja_JP: startTime
+            pt_BR: startTime
+            zh_Hans: startTime
+          llm_description: Data query start time(Microsecond)
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Data query end time(Microsecond)
+            ja_JP: Data query end time(Microsecond)
+            pt_BR: Data query end time(Microsecond)
+            zh_Hans: 结束时间 (微秒)
+          label:
+            en_US: endTime
+            ja_JP: endTime
+            pt_BR: endTime
+            zh_Hans: endTime
+          llm_description: Data query end time(Microsecond)
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          endTime: ''
+          endpoint: ''
+          service: ''
+          startTime: ''
+          type: ''
+        provider_id: apo_select
+        provider_name: apo_select
+        provider_type: builtin
+        selected: false
+        title: 查询服务Runq方向根因报告
+        tool_configurations: {}
+        tool_label: 查询服务根因报告
+        tool_name: 查询服务根因报告
+        tool_parameters:
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          endpoint:
+            type: mixed
+            value: '{{#1742807803325.endpoint#}}'
+          service:
+            type: mixed
+            value: '{{#1742807803325.service#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+          type:
+            type: mixed
+            value: scheduling_time
+        type: tool
+      height: 54
+      id: '17515048888700'
+      position:
+        x: 4870
+        y: 1358
+      positionAbsolute:
+        x: 4870
+        y: 1358
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import json\n\n\ndef _get_avg(values):\n    if not values:\n      \
+          \  return 0\n    return sum(values) / len(values)\n\ndef _get_standard_deviation(avg,\
+          \ values):\n    if len(values) == 0:\n        return 0\n    squared_diffs\
+          \ = [(x - avg)**2 for x in values]\n    sum_squared_diffs = sum(squared_diffs)\n\
+          \    variance = sum_squared_diffs / (len(values))\n    return variance**0.5\n\
+          \ndef analyze_data(result_str: str):        \n\n        data = json.loads(result_str)\n\
+          \        timeseries = data.get('data', {}).get('timeseries', [])\n     \
+          \   unit = data.get('unit', '')\n        filtered = []\n\n        for entry\
+          \ in timeseries:\n            labels = entry.get('labels', {})\n\n     \
+          \       chart = entry.get('chart', {}).get('chartData', {})\n          \
+          \  values = [v for v in chart.values() if v != 0]\n\n            if len(values)\
+          \ == 0:\n                continue\n\n            avg = _get_avg(values)\n\
+          \            variance = _get_standard_deviation(avg, values)\n\n       \
+          \     threshold = avg + 1 * variance\n            \n            count =\
+          \ 0\n            for _, value in chart.items():\n                if value\
+          \ > 0.05:\n                    count += 1\n\n            if count != 0:\n\
+          \                res = {\n                    \"chart\": chart,\n      \
+          \              \"abnormalCount\": count,\n                    \"labels\"\
+          : labels,\n                    \"avg\": avg,\n                    \"unit\"\
+          : unit\n                }\n                filtered.append(res)\n      \
+          \          \n\n        return json.dumps(filtered)\n    \ndef main(arg1:\
+          \ str) -> dict:\n    res = analyze_data(arg1)\n    return {\n        \"\
+          result\": res,\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: RTT分析
+        type: code
+        variables:
+        - value_selector:
+          - '17473562733380'
+          - text
+          variable: arg1
+      height: 54
+      id: '17515143872690'
+      position:
+        x: 4566
+        y: 903
+      positionAbsolute:
+        x: 4566
+        y: 903
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: alertEventId
+            ja_JP: alertEventId
+            pt_BR: alertEventId
+            zh_Hans: 报告类型
+          label:
+            en_US: alertEventId
+            ja_JP: alertEventId
+            pt_BR: alertEventId
+            zh_Hans: 告警事件ID
+          llm_description: alertEventId
+          max: null
+          min: null
+          name: alertEventId
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportText
+            ja_JP: reportText
+            pt_BR: reportText
+            zh_Hans: 报告简要文本
+          label:
+            en_US: reportText
+            ja_JP: reportText
+            pt_BR: reportText
+            zh_Hans: 报告简要文本
+          llm_description: reportText
+          max: null
+          min: null
+          name: reportText
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: frontPrefix
+            ja_JP: frontPrefix
+            pt_BR: frontPrefix
+            zh_Hans: 报告访问地址
+          label:
+            en_US: frontPrefix
+            ja_JP: frontPrefix
+            pt_BR: frontPrefix
+            zh_Hans: 报告访问地址
+          llm_description: frontPrefix
+          max: null
+          min: null
+          name: frontPrefix
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Start timestamp in microseconds
+            ja_JP: Start timestamp in microseconds
+            pt_BR: Start timestamp in microseconds
+            zh_Hans: 查询开始时间（微秒）
+          label:
+            en_US: Start Time
+            ja_JP: Start Time
+            pt_BR: Start Time
+            zh_Hans: 开始时间
+          llm_description: Microsecond timestamp for start time
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: End timestamp in microseconds
+            ja_JP: End timestamp in microseconds
+            pt_BR: End timestamp in microseconds
+            zh_Hans: 查询结束时间（微秒）
+          label:
+            en_US: End Time
+            ja_JP: End Time
+            pt_BR: End Time
+            zh_Hans: 结束时间
+          llm_description: Microsecond timestamp for end time
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          alertEventId: ''
+          endTime: ''
+          frontPrefix: ''
+          reportText: ''
+          startTime: ''
+        provider_id: apo_analysis
+        provider_name: apo_analysis
+        provider_type: builtin
+        selected: false
+        title: 获取告警分析报告链接
+        tool_configurations: {}
+        tool_label: 获取告警分析报告链接
+        tool_name: get alert report url
+        tool_parameters:
+          alertEventId:
+            type: mixed
+            value: '{{#1742807803325.alertEventId#}}'
+          endTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - endTime
+          frontPrefix:
+            type: mixed
+            value: ''
+          reportText:
+            type: mixed
+            value: '{{#1750662084996.text#}}'
+          startTime:
+            type: variable
+            value:
+            - '1741227526517'
+            - startTime
+        type: tool
+      height: 54
+      id: '1751601681225'
+      position:
+        x: 14769
+        y: 1146
+      positionAbsolute:
+        x: 14769
+        y: 1146
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        cases:
+        - case_id: 'true'
+          conditions:
+          - comparison_operator: is
+            id: 77200336-55fa-4c9c-bfac-43d16e54f3ed
+            value: ce
+            varType: string
+            variable_selector:
+            - '1741227526517'
+            - edition
+          id: 'true'
+          logical_operator: and
+        desc: ''
+        selected: false
+        title: report
+        type: if-else
+      height: 126
+      id: '1751601842740'
+      position:
+        x: 12345
+        y: 904
+      positionAbsolute:
+        x: 12345
+        y: 904
+      selected: true
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        outputs:
+        - value_selector:
+          - '1741512806512'
+          - text
+          variable: text
+        selected: false
+        title: 结束 5
+        type: end
+      height: 90
+      id: '1751601994805'
+      position:
+        x: 12719.594033345926
+        y: 780.9445175572653
+      positionAbsolute:
+        x: 12719.594033345926
+        y: 780.9445175572653
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
     viewport:
-      x: -1412.1614583577787
-      y: -301.56227612100827
-      zoom: 0.4013834336531662
+      x: 320.13973239264504
+      y: -276.21943788755914
+      zoom: 0.9756601814364348

--- a/api/init_data/workflows/zh/资源告警分析.yml
+++ b/api/init_data/workflows/zh/资源告警分析.yml
@@ -10205,7 +10205,7 @@ workflow:
             value: infra
           rootCauseAnalysis:
             type: mixed
-            value: '{{#1751617706952.text#}}'
+            value: '{{#1751617715636.result#}}'
           suggest:
             type: mixed
             value: '{{#1750990570740.result#}}'
@@ -10809,7 +10809,7 @@ workflow:
             children: null
             type: string
         selected: false
-        title: 根因方向
+        title: 根因方向JSON
         type: code
         variables:
         - value_selector:
@@ -10830,6 +10830,6 @@ workflow:
       type: custom
       width: 244
     viewport:
-      x: -4387.795490058535
-      y: -718.0004622031324
+      x: -4400.795490058535
+      y: -748.0004622031324
       zoom: 0.7257823889922984

--- a/api/init_data/workflows/zh/资源告警分析.yml
+++ b/api/init_data/workflows/zh/资源告警分析.yml
@@ -9,7 +9,7 @@ dependencies:
 - current_identifier: null
   type: package
   value:
-    plugin_unique_identifier: langgenius/deepseek:0.0.5@fd6efd37c2a931911de8ab9ca3ba2da303bef146d45ee87ad896b04b36d09403
+    plugin_unique_identifier: langgenius/openai_api_compatible:0.0.7@f20c7275bbcf055ec5d170dd5128e341986e2dcba5266d08fd080d4bdf2288f6
 kind: app
 version: 0.1.5
 workflow:
@@ -525,40 +525,6 @@ workflow:
       source: '17438490633890'
       sourceHandle: source
       target: '1743850218410'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: variable-aggregator
-        targetType: end
-      id: 1743850218410-source-17438490239160-target
-      selected: false
-      source: '1743850218410'
-      sourceHandle: source
-      target: '17438490239160'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: code
-        targetType: question-classifier
-      id: 1743670061370-source-1743577315409-target
-      source: '1743670061370'
-      sourceHandle: source
-      target: '1743577315409'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
-        sourceType: code
-        targetType: question-classifier
-      id: 1743670099979-source-1743577315409-target
-      source: '1743670099979'
-      sourceHandle: source
-      target: '1743577315409'
       targetHandle: target
       type: custom
       zIndex: 0
@@ -1155,17 +1121,6 @@ workflow:
       zIndex: 0
     - data:
         isInIteration: false
-        sourceType: code
-        targetType: question-classifier
-      id: 17469670619810-source-1743577315409-target
-      source: '17469670619810'
-      sourceHandle: source
-      target: '1743577315409'
-      targetHandle: target
-      type: custom
-      zIndex: 0
-    - data:
-        isInIteration: false
         sourceType: if-else
         targetType: if-else
       id: 1743844014629-true-1746967296261-target
@@ -1520,6 +1475,7 @@ workflow:
         sourceType: question-classifier
         targetType: tool
       id: 1743577315409-1743584285389-1747645046499-target
+      selected: false
       source: '1743577315409'
       sourceHandle: '1743584285389'
       target: '1747645046499'
@@ -1592,10 +1548,219 @@ workflow:
       targetHandle: target
       type: custom
       zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: if-else
+      id: 17469670619810-source-1750387980645-target
+      source: '17469670619810'
+      sourceHandle: source
+      target: '1750387980645'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: if-else
+      id: 1743670099979-source-1750387980645-target
+      source: '1743670099979'
+      sourceHandle: source
+      target: '1750387980645'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: if-else
+      id: 1743670061370-source-1750387980645-target
+      source: '1743670061370'
+      sourceHandle: source
+      target: '1750387980645'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: question-classifier
+      id: 1750387980645-false-1743577315409-target
+      source: '1750387980645'
+      sourceHandle: 'false'
+      target: '1743577315409'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: tool
+      id: 1750387980645-true-1747645046499-target
+      source: '1750387980645'
+      sourceHandle: 'true'
+      target: '1747645046499'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750988333220-source-1750988315593-target
+      source: '1750988333220'
+      sourceHandle: source
+      target: '1750988315593'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750988484023-source-1750988315593-target
+      source: '1750988484023'
+      sourceHandle: source
+      target: '1750988315593'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750988845336-source-1750988484023-target
+      source: '1750988845336'
+      sourceHandle: source
+      target: '1750988484023'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: llm
+      id: 1750988869166-source-1750988845336-target
+      source: '1750988869166'
+      sourceHandle: source
+      target: '1750988845336'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1750990566608-source-1750990570740-target
+      source: '1750990566608'
+      sourceHandle: source
+      target: '1750990570740'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1750990570740-source-1750988315593-target
+      source: '1750990570740'
+      sourceHandle: source
+      target: '1750988315593'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: end
+      id: 1750995788076-source-17438490239160-target
+      source: '1750995788076'
+      sourceHandle: source
+      target: '17438490239160'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: llm
+      id: 1751602121596-source-1750995788076-target
+      source: '1751602121596'
+      sourceHandle: source
+      target: '1750995788076'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: tool
+        targetType: tool
+      id: 1750988315593-source-1751602121596-target
+      source: '1750988315593'
+      sourceHandle: source
+      target: '1751602121596'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: variable-aggregator
+        targetType: if-else
+      id: 1743850218410-source-1751602227575-target
+      source: '1743850218410'
+      sourceHandle: source
+      target: '1751602227575'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602227575-false-1750990566608-target
+      source: '1751602227575'
+      sourceHandle: 'false'
+      target: '1750990566608'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602227575-false-1750988869166-target
+      source: '1751602227575'
+      sourceHandle: 'false'
+      target: '1750988869166'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: code
+      id: 1751602227575-false-1750988333220-target
+      source: '1751602227575'
+      sourceHandle: 'false'
+      target: '1750988333220'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: end
+      id: 1751602227575-true-1751602318456-target
+      source: '1751602227575'
+      sourceHandle: 'true'
+      target: '1751602318456'
+      targetHandle: target
+      type: custom
+      zIndex: 0
     nodes:
     - data:
         desc: ''
-        selected: false
+        selected: true
         title: 开始
         type: start
         variables:
@@ -1623,7 +1788,13 @@ workflow:
           required: false
           type: text-input
           variable: nodeName
-      height: 168
+        - label: edition
+          max_length: 48
+          options: []
+          required: false
+          type: paragraph
+          variable: edition
+      height: 194
       id: '1743576019537'
       position:
         x: 30
@@ -1631,7 +1802,7 @@ workflow:
       positionAbsolute:
         x: 30
         y: 299
-      selected: false
+      selected: true
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -1667,8 +1838,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1744959389144'
         - alertName
@@ -1678,14 +1849,14 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 492
+      height: 498
       id: '1743577315409'
       position:
-        x: 2151
-        y: 519
+        x: 2448
+        y: 2833
       positionAbsolute:
-        x: 2151
-        y: 519
+        x: 2448
+        y: 2833
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -1749,10 +1920,10 @@ workflow:
       height: 54
       id: '1743650887693'
       position:
-        x: 939
+        x: 938
         y: 299
       positionAbsolute:
-        x: 939
+        x: 938
         y: 299
       selected: false
       sourcePosition: right
@@ -1772,10 +1943,10 @@ workflow:
       height: 90
       id: '1743650967123'
       position:
-        x: 1242
+        x: 1240
         y: 299
       positionAbsolute:
-        x: 1242
+        x: 1240
         y: 299
       selected: false
       sourcePosition: right
@@ -1917,10 +2088,10 @@ workflow:
       height: 54
       id: '1743652485397'
       position:
-        x: 939
+        x: 938
         y: 409
       positionAbsolute:
-        x: 939
+        x: 938
         y: 409
       selected: false
       sourcePosition: right
@@ -1956,10 +2127,10 @@ workflow:
       height: 54
       id: '1743652552181'
       position:
-        x: 1242
+        x: 1240
         y: 427
       positionAbsolute:
-        x: 1242
+        x: 1240
         y: 427
       selected: false
       sourcePosition: right
@@ -1977,13 +2148,13 @@ workflow:
           - result
         - - '1743652552181'
           - result
-      height: 131
+      height: 130
       id: '1743664106885'
       position:
-        x: 1545
+        x: 1542
         y: 409
       positionAbsolute:
-        x: 1545
+        x: 1542
         y: 409
       selected: false
       sourcePosition: right
@@ -2016,10 +2187,10 @@ workflow:
       height: 54
       id: '1743664113196'
       position:
-        x: 1242
+        x: 1240
         y: 519
       positionAbsolute:
-        x: 1242
+        x: 1240
         y: 519
       selected: false
       sourcePosition: right
@@ -2189,11 +2360,11 @@ workflow:
       height: 54
       id: '1743668416211'
       position:
-        x: 3969
-        y: 2574
+        x: 4260
+        y: 2559
       positionAbsolute:
-        x: 3969
-        y: 2574
+        x: 4260
+        y: 2559
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2222,11 +2393,11 @@ workflow:
       height: 54
       id: '1743670061370'
       position:
-        x: 1848
-        y: 611
+        x: 1844
+        y: 409
       positionAbsolute:
-        x: 1848
-        y: 611
+        x: 1844
+        y: 409
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2254,11 +2425,11 @@ workflow:
       height: 54
       id: '1743670099979'
       position:
-        x: 1848
-        y: 519
+        x: 1844
+        y: 2558
       positionAbsolute:
-        x: 1848
-        y: 519
+        x: 1844
+        y: 2558
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2399,11 +2570,11 @@ workflow:
       height: 54
       id: '1743672102038'
       position:
-        x: 3969
-        y: 3330
+        x: 4260
+        y: 3370
       positionAbsolute:
-        x: 3969
-        y: 3330
+        x: 4260
+        y: 3370
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2553,11 +2724,11 @@ workflow:
       height: 54
       id: '1743672656692'
       position:
-        x: 3969
-        y: 3238
+        x: 4260
+        y: 3278
       positionAbsolute:
-        x: 3969
-        y: 3238
+        x: 4260
+        y: 3278
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2726,11 +2897,11 @@ workflow:
       height: 54
       id: '1743672756524'
       position:
-        x: 3969
-        y: 3146
+        x: 4260
+        y: 3186
       positionAbsolute:
-        x: 3969
-        y: 3146
+        x: 4260
+        y: 3186
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -2899,11 +3070,11 @@ workflow:
       height: 54
       id: '1743672762507'
       position:
-        x: 3969
-        y: 3054
+        x: 4260
+        y: 3094
       positionAbsolute:
-        x: 3969
-        y: 3054
+        x: 4260
+        y: 3094
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3069,11 +3240,11 @@ workflow:
       height: 54
       id: '1743673124913'
       position:
-        x: 3969
-        y: 2962
+        x: 4260
+        y: 3002
       positionAbsolute:
-        x: 3969
-        y: 2962
+        x: 4260
+        y: 3002
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3239,11 +3410,11 @@ workflow:
       height: 54
       id: '1743673153877'
       position:
-        x: 3969
-        y: 2870
+        x: 4260
+        y: 2910
       positionAbsolute:
-        x: 3969
-        y: 2870
+        x: 4260
+        y: 2910
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3276,14 +3447,14 @@ workflow:
           - text
         - - '1747645046499'
           - text
-      height: 307
+      height: 306
       id: '1743673518843'
       position:
-        x: 4272
-        y: 2683.5
+        x: 4562
+        y: 2727
       positionAbsolute:
-        x: 4272
-        y: 2683.5
+        x: 4562
+        y: 2727
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3298,8 +3469,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -3342,14 +3513,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '1743673613633'
       position:
-        x: 5181
-        y: 2810
+        x: 5468
+        y: 2853
       positionAbsolute:
-        x: 5181
-        y: 2810
+        x: 5468
+        y: 2853
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3375,10 +3546,10 @@ workflow:
       height: 126
       id: '1743844014629'
       position:
-        x: 2454
+        x: 2750
         y: 941
       positionAbsolute:
-        x: 2454
+        x: 2750
         y: 941
       selected: false
       sourcePosition: right
@@ -3405,10 +3576,10 @@ workflow:
       height: 126
       id: '17438442246820'
       position:
-        x: 3060
+        x: 3354
         y: 721
       positionAbsolute:
-        x: 3060
+        x: 3354
         y: 721
       selected: false
       sourcePosition: right
@@ -3428,10 +3599,10 @@ workflow:
       height: 90
       id: '1743844231109'
       position:
-        x: 3060
+        x: 3354
         y: 593
       positionAbsolute:
-        x: 3060
+        x: 3354
         y: 593
       selected: false
       sourcePosition: right
@@ -3461,8 +3632,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1746777077402'
         - text
@@ -3472,14 +3643,14 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 168
+      height: 174
       id: '1743846657026'
       position:
-        x: 3363
-        y: 1574
+        x: 3656
+        y: 1565
       positionAbsolute:
-        x: 3363
-        y: 1574
+        x: 3656
+        y: 1565
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3495,10 +3666,10 @@ workflow:
       height: 54
       id: '1743847092222'
       position:
-        x: 2757
+        x: 3052
         y: 593
       positionAbsolute:
-        x: 2757
+        x: 3052
         y: 593
       selected: false
       sourcePosition: right
@@ -3665,11 +3836,11 @@ workflow:
       height: 54
       id: '1743847425675'
       position:
-        x: 4272
-        y: 1598
+        x: 4562
+        y: 1586
       positionAbsolute:
-        x: 4272
-        y: 1598
+        x: 4562
+        y: 1586
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3782,11 +3953,11 @@ workflow:
       height: 54
       id: '1743847618976'
       position:
-        x: 3969
-        y: 2778
+        x: 4260
+        y: 2818
       positionAbsolute:
-        x: 3969
-        y: 2778
+        x: 4260
+        y: 2818
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -3952,11 +4123,11 @@ workflow:
       height: 54
       id: '1743847703261'
       position:
-        x: 4272
-        y: 1690
+        x: 4562
+        y: 1678
       positionAbsolute:
-        x: 4272
-        y: 1690
+        x: 4562
+        y: 1678
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4122,11 +4293,11 @@ workflow:
       height: 54
       id: '1743848302527'
       position:
-        x: 4272
-        y: 2150
+        x: 4562
+        y: 2138
       positionAbsolute:
-        x: 4272
-        y: 2150
+        x: 4562
+        y: 2138
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4292,11 +4463,11 @@ workflow:
       height: 54
       id: '1743848306370'
       position:
-        x: 4272
-        y: 2058
+        x: 4562
+        y: 2046
       positionAbsolute:
-        x: 4272
-        y: 2058
+        x: 4562
+        y: 2046
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4462,11 +4633,11 @@ workflow:
       height: 54
       id: '1743848316998'
       position:
-        x: 4272
-        y: 1966
+        x: 4562
+        y: 1954
       positionAbsolute:
-        x: 4272
-        y: 1966
+        x: 4562
+        y: 1954
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4632,11 +4803,11 @@ workflow:
       height: 54
       id: '1743848323475'
       position:
-        x: 4272
-        y: 1874
+        x: 4562
+        y: 1862
       positionAbsolute:
-        x: 4272
-        y: 1874
+        x: 4562
+        y: 1862
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4651,8 +4822,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -4685,14 +4856,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17438483761510'
       position:
-        x: 5181
-        y: 1966
+        x: 5468
+        y: 1954
       positionAbsolute:
-        x: 5181
-        y: 1966
+        x: 5468
+        y: 1954
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4705,17 +4876,25 @@ workflow:
           - '1743850218410'
           - output
           variable: text
+        - value_selector:
+          - '1751602121596'
+          - text
+          variable: output
+        - value_selector:
+          - '1750995788076'
+          - text
+          variable: alertDirection
         selected: false
         title: 结论
         type: end
-      height: 90
+      height: 142
       id: '17438490239160'
       position:
-        x: 5787
-        y: 1464
+        x: 8192
+        y: 1662
       positionAbsolute:
-        x: 5787
-        y: 1464
+        x: 8192
+        y: 1662
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4730,8 +4909,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -4764,14 +4943,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17438490633890'
       position:
-        x: 5181
-        y: 1598
+        x: 5468
+        y: 1586
       positionAbsolute:
-        x: 5181
-        y: 1598
+        x: 5468
+        y: 1586
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4912,11 +5091,11 @@ workflow:
       height: 54
       id: '1743849441196'
       position:
-        x: 3666
-        y: 1616
+        x: 3958
+        y: 1604
       positionAbsolute:
-        x: 3666
-        y: 1616
+        x: 3958
+        y: 1604
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -4939,14 +5118,19 @@ workflow:
           根据告警{{#1743576019537.alertName#}}和指标值{{#1743849441196.text#}}判断该指标是否在某一时刻飙升
 
 
+          # 注意
+
+          如果没有查询到数据，认为指标没有异常
+
+
           '
         instructions: ''
         model:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1743849441196'
         - text
@@ -4956,15 +5140,15 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 168
+      height: 174
       id: '17438494733730'
       position:
-        x: 3969
-        y: 1574
+        x: 4260
+        y: 1586
       positionAbsolute:
-        x: 3969
-        y: 1574
-      selected: true
+        x: 4260
+        y: 1586
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -5129,11 +5313,11 @@ workflow:
       height: 54
       id: '1743849875119'
       position:
-        x: 4272
-        y: 1782
+        x: 4562
+        y: 1770
       positionAbsolute:
-        x: 4272
-        y: 1782
+        x: 4562
+        y: 1770
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5148,8 +5332,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -5182,14 +5366,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17438498987710'
       position:
-        x: 5181
-        y: 1782
+        x: 5468
+        y: 1770
       positionAbsolute:
-        x: 5181
-        y: 1782
+        x: 5468
+        y: 1770
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5220,14 +5404,14 @@ workflow:
           - text
         - - '17472781853800'
           - text
-      height: 285
+      height: 284
       id: '1743850218410'
       position:
-        x: 5484
-        y: 1464
+        x: 5770
+        y: 1458
       positionAbsolute:
-        x: 5484
-        y: 1464
+        x: 5770
+        y: 1458
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5340,10 +5524,10 @@ workflow:
       height: 54
       id: '1743850453842'
       position:
-        x: 4878
+        x: 5166
         y: 519
       positionAbsolute:
-        x: 4878
+        x: 5166
         y: 519
       selected: false
       sourcePosition: right
@@ -5360,13 +5544,17 @@ workflow:
           \        \"jobName\": \".*\",\n        \"containerId\": get_value(data,\
           \ [\"containerId\", \"container_id\", \"containerID\"]),\n        \"pid\"\
           : get_value(data, [\"pid\", \"process_id\", \"processId\"]),\n        \"\
-          instanceName\": get_value(data, [\"instanceName\", \"instance_name\"])\n\
-          \    }\n\n  \ndef get_value(data, keys): \n  for key in keys: \n    value\
-          \ = data.get(key) \n    if value is not None: \n      return value \n  return\
-          \ \"\" \n"
+          instanceName\": get_value(data, [\"instanceName\", \"instance_name\"]),\n\
+          \        \"service\": get_value(data, [\"service\"]),\n        \"alertEventId\"\
+          : get_value(data, [\"alertEventId\"])\n    }\n\n  \ndef get_value(data,\
+          \ keys): \n  for key in keys: \n    value = data.get(key) \n    if value\
+          \ is not None: \n      return value \n  return \"\" \n"
         code_language: python3
         desc: ''
         outputs:
+          alertEventId:
+            children: null
+            type: string
           alertName:
             children: null
             type: string
@@ -5391,6 +5579,9 @@ workflow:
           pod:
             children: null
             type: string
+          service:
+            children: null
+            type: string
         selected: false
         title: 获取参数
         type: code
@@ -5406,10 +5597,10 @@ workflow:
       height: 54
       id: '1744959389144'
       position:
-        x: 333
+        x: 334
         y: 299
       positionAbsolute:
-        x: 333
+        x: 334
         y: 299
       selected: false
       sourcePosition: right
@@ -5463,11 +5654,11 @@ workflow:
       height: 54
       id: '1745224561449'
       position:
-        x: 4575
-        y: 2902
+        x: 4864
+        y: 2945
       positionAbsolute:
-        x: 4575
-        y: 2902
+        x: 4864
+        y: 2945
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5520,11 +5711,11 @@ workflow:
       height: 54
       id: '1745228455097'
       position:
-        x: 4575
-        y: 2150
+        x: 4864
+        y: 2138
       positionAbsolute:
-        x: 4575
-        y: 2150
+        x: 4864
+        y: 2138
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5577,11 +5768,11 @@ workflow:
       height: 54
       id: '1745228463913'
       position:
-        x: 4575
-        y: 2058
+        x: 4864
+        y: 2046
       positionAbsolute:
-        x: 4575
-        y: 2058
+        x: 4864
+        y: 2046
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5634,11 +5825,11 @@ workflow:
       height: 54
       id: '1745228471960'
       position:
-        x: 4575
-        y: 1966
+        x: 4864
+        y: 1954
       positionAbsolute:
-        x: 4575
-        y: 1966
+        x: 4864
+        y: 1954
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5691,11 +5882,11 @@ workflow:
       height: 54
       id: '1745228478308'
       position:
-        x: 4575
-        y: 1874
+        x: 4864
+        y: 1862
       positionAbsolute:
-        x: 4575
-        y: 1874
+        x: 4864
+        y: 1862
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5748,11 +5939,11 @@ workflow:
       height: 54
       id: '1745228513830'
       position:
-        x: 4575
-        y: 1598
+        x: 4864
+        y: 1586
       positionAbsolute:
-        x: 4575
-        y: 1598
+        x: 4864
+        y: 1586
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5805,11 +5996,11 @@ workflow:
       height: 54
       id: '1745228520609'
       position:
-        x: 4575
-        y: 1690
+        x: 4864
+        y: 1678
       positionAbsolute:
-        x: 4575
-        y: 1690
+        x: 4864
+        y: 1678
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5862,11 +6053,11 @@ workflow:
       height: 54
       id: '1745228528400'
       position:
-        x: 4575
-        y: 1782
+        x: 4864
+        y: 1770
       positionAbsolute:
-        x: 4575
-        y: 1782
+        x: 4864
+        y: 1770
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5919,11 +6110,11 @@ workflow:
       height: 54
       id: '1745894017978'
       position:
-        x: 4878
-        y: 2902
+        x: 5166
+        y: 2945
       positionAbsolute:
-        x: 4878
-        y: 2902
+        x: 5166
+        y: 2945
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -5976,11 +6167,11 @@ workflow:
       height: 54
       id: '17458959866650'
       position:
-        x: 4878
-        y: 2150
+        x: 5166
+        y: 2138
       positionAbsolute:
-        x: 4878
-        y: 2150
+        x: 5166
+        y: 2138
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6033,11 +6224,11 @@ workflow:
       height: 54
       id: '17458959879420'
       position:
-        x: 4878
-        y: 1874
+        x: 5166
+        y: 1862
       positionAbsolute:
-        x: 4878
-        y: 1874
+        x: 5166
+        y: 1862
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6090,11 +6281,11 @@ workflow:
       height: 54
       id: '17458959892670'
       position:
-        x: 4878
-        y: 2058
+        x: 5166
+        y: 2046
       positionAbsolute:
-        x: 4878
-        y: 2058
+        x: 5166
+        y: 2046
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6147,11 +6338,11 @@ workflow:
       height: 54
       id: '17458959903430'
       position:
-        x: 4878
-        y: 1966
+        x: 5166
+        y: 1954
       positionAbsolute:
-        x: 4878
-        y: 1966
+        x: 5166
+        y: 1954
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6204,11 +6395,11 @@ workflow:
       height: 54
       id: '17459056426090'
       position:
-        x: 4878
-        y: 1690
+        x: 5166
+        y: 1678
       positionAbsolute:
-        x: 4878
-        y: 1690
+        x: 5166
+        y: 1678
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6261,11 +6452,11 @@ workflow:
       height: 54
       id: '17459056606540'
       position:
-        x: 4878
-        y: 1598
+        x: 5166
+        y: 1586
       positionAbsolute:
-        x: 4878
-        y: 1598
+        x: 5166
+        y: 1586
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6318,11 +6509,11 @@ workflow:
       height: 54
       id: '17459186208040'
       position:
-        x: 4878
-        y: 1782
+        x: 5166
+        y: 1770
       positionAbsolute:
-        x: 4878
-        y: 1782
+        x: 5166
+        y: 1770
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6348,11 +6539,11 @@ workflow:
       height: 126
       id: '17459265895570'
       position:
-        x: 3666
-        y: 2224
+        x: 3958
+        y: 2212
       positionAbsolute:
-        x: 3666
-        y: 2224
+        x: 3958
+        y: 2212
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6368,11 +6559,11 @@ workflow:
       height: 54
       id: '1745926623499'
       position:
-        x: 4878
-        y: 1333
+        x: 5166
+        y: 1330
       positionAbsolute:
-        x: 4878
-        y: 1333
+        x: 5166
+        y: 1330
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6391,11 +6582,11 @@ workflow:
       height: 90
       id: '1745926643387'
       position:
-        x: 5181
-        y: 1336
+        x: 5468
+        y: 1330
       positionAbsolute:
-        x: 5181
-        y: 1336
+        x: 5468
+        y: 1330
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6421,10 +6612,10 @@ workflow:
       height: 126
       id: '17459267080670'
       position:
-        x: 4575
+        x: 4864
         y: 483
       positionAbsolute:
-        x: 4575
+        x: 4864
         y: 483
       selected: false
       sourcePosition: right
@@ -6566,11 +6757,11 @@ workflow:
       height: 54
       id: '1746777077402'
       position:
-        x: 3060
-        y: 1616
+        x: 3354
+        y: 1604
       positionAbsolute:
-        x: 3060
-        y: 1616
+        x: 3354
+        y: 1604
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6711,11 +6902,11 @@ workflow:
       height: 54
       id: '17467775030610'
       position:
-        x: 3666
-        y: 1167
+        x: 3958
+        y: 1164
       positionAbsolute:
-        x: 3666
-        y: 1167
+        x: 3958
+        y: 1164
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6735,7 +6926,9 @@ workflow:
 
           # 判断思路
 
-          根据告警{{#1743576019537.alertName#}}和指标值{{#17467775030610.text#}}判断该指标是否在某一时刻飙升
+          根据告警{{#1743576019537.alertName#}}，然后判读判断该指标是否在某一时刻飙升
+
+          如果指标数据为空，认为没有异常
 
 
           '
@@ -6744,8 +6937,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '17467775030610'
         - text
@@ -6755,14 +6948,14 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 168
+      height: 174
       id: '17467775030611'
       position:
-        x: 3969
-        y: 1149
+        x: 4260
+        y: 1146
       positionAbsolute:
-        x: 3969
-        y: 1149
+        x: 4260
+        y: 1146
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -6781,10 +6974,10 @@ workflow:
       height: 90
       id: '17467775269230'
       position:
-        x: 3666
+        x: 3958
         y: 867
       positionAbsolute:
-        x: 3666
+        x: 3958
         y: 867
       selected: false
       sourcePosition: right
@@ -6801,10 +6994,10 @@ workflow:
       height: 54
       id: '17467775269231'
       position:
-        x: 3363
+        x: 3656
         y: 903
       positionAbsolute:
-        x: 3363
+        x: 3656
         y: 903
       selected: false
       sourcePosition: right
@@ -6971,11 +7164,11 @@ workflow:
       height: 54
       id: '17467776423960'
       position:
-        x: 4272
-        y: 1241
+        x: 4562
+        y: 1238
       positionAbsolute:
-        x: 4272
-        y: 1241
+        x: 4562
+        y: 1238
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7141,11 +7334,11 @@ workflow:
       height: 54
       id: '17467776423971'
       position:
-        x: 4272
-        y: 1149
+        x: 4562
+        y: 1146
       positionAbsolute:
-        x: 4272
-        y: 1149
+        x: 4562
+        y: 1146
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7160,8 +7353,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -7194,14 +7387,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17467776423972'
       position:
-        x: 5181
-        y: 1149
+        x: 5468
+        y: 1146
       positionAbsolute:
-        x: 5181
-        y: 1149
+        x: 5468
+        y: 1146
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7367,11 +7560,11 @@ workflow:
       height: 54
       id: '17467776423973'
       position:
-        x: 4272
-        y: 1464
+        x: 4562
+        y: 1458
       positionAbsolute:
-        x: 4272
-        y: 1464
+        x: 4562
+        y: 1458
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7386,8 +7579,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -7420,14 +7613,14 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17467776423974'
       position:
-        x: 5181
-        y: 1464
+        x: 5468
+        y: 1458
       positionAbsolute:
-        x: 5181
-        y: 1464
+        x: 5468
+        y: 1458
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7480,11 +7673,11 @@ workflow:
       height: 54
       id: '17467776423975'
       position:
-        x: 4575
-        y: 1241
+        x: 4864
+        y: 1238
       positionAbsolute:
-        x: 4575
-        y: 1241
+        x: 4864
+        y: 1238
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7537,11 +7730,11 @@ workflow:
       height: 54
       id: '17467776423976'
       position:
-        x: 4575
-        y: 1149
+        x: 4864
+        y: 1146
       positionAbsolute:
-        x: 4575
-        y: 1149
+        x: 4864
+        y: 1146
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7594,11 +7787,11 @@ workflow:
       height: 54
       id: '17467776423977'
       position:
-        x: 4575
-        y: 1464
+        x: 4864
+        y: 1458
       positionAbsolute:
-        x: 4575
-        y: 1464
+        x: 4864
+        y: 1458
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7651,11 +7844,11 @@ workflow:
       height: 54
       id: '17467776423978'
       position:
-        x: 4878
-        y: 1149
+        x: 5166
+        y: 1146
       positionAbsolute:
-        x: 4878
-        y: 1149
+        x: 5166
+        y: 1146
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7708,11 +7901,11 @@ workflow:
       height: 54
       id: '17467776423979'
       position:
-        x: 4878
-        y: 1241
+        x: 5166
+        y: 1238
       positionAbsolute:
-        x: 4878
-        y: 1241
+        x: 5166
+        y: 1238
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7765,11 +7958,11 @@ workflow:
       height: 54
       id: '174677764239710'
       position:
-        x: 4878
-        y: 1464
+        x: 5166
+        y: 1458
       positionAbsolute:
-        x: 4878
-        y: 1464
+        x: 5166
+        y: 1458
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7797,11 +7990,11 @@ workflow:
       height: 54
       id: '17469670619810'
       position:
-        x: 1848
-        y: 409
+        x: 1844
+        y: 2650
       positionAbsolute:
-        x: 1848
-        y: 409
+        x: 1844
+        y: 2650
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -7827,10 +8020,10 @@ workflow:
       height: 126
       id: '1746967296261'
       position:
-        x: 2757
+        x: 3052
         y: 905
       positionAbsolute:
-        x: 2757
+        x: 3052
         y: 905
       selected: false
       sourcePosition: right
@@ -7973,10 +8166,10 @@ workflow:
       height: 54
       id: '1746967506328'
       position:
-        x: 4272
+        x: 4562
         y: 1033
       positionAbsolute:
-        x: 4272
+        x: 4562
         y: 1033
       selected: false
       sourcePosition: right
@@ -8030,10 +8223,10 @@ workflow:
       height: 54
       id: '17469677133940'
       position:
-        x: 4575
+        x: 4864
         y: 1033
       positionAbsolute:
-        x: 4575
+        x: 4864
         y: 1033
       selected: false
       sourcePosition: right
@@ -8087,10 +8280,10 @@ workflow:
       height: 54
       id: '17469677643700'
       position:
-        x: 4878
+        x: 5166
         y: 1033
       positionAbsolute:
-        x: 4878
+        x: 5166
         y: 1033
       selected: false
       sourcePosition: right
@@ -8233,10 +8426,10 @@ workflow:
       height: 54
       id: '17469679277020'
       position:
-        x: 4272
+        x: 4562
         y: 941
       positionAbsolute:
-        x: 4272
+        x: 4562
         y: 941
       selected: false
       sourcePosition: right
@@ -8290,10 +8483,10 @@ workflow:
       height: 54
       id: '17469681597400'
       position:
-        x: 4575
+        x: 4864
         y: 941
       positionAbsolute:
-        x: 4575
+        x: 4864
         y: 941
       selected: false
       sourcePosition: right
@@ -8347,10 +8540,10 @@ workflow:
       height: 54
       id: '17469681675370'
       position:
-        x: 4878
+        x: 5166
         y: 941
       positionAbsolute:
-        x: 4878
+        x: 5166
         y: 941
       selected: false
       sourcePosition: right
@@ -8493,10 +8686,10 @@ workflow:
       height: 54
       id: '17469682833510'
       position:
-        x: 4272
+        x: 4562
         y: 391
       positionAbsolute:
-        x: 4272
+        x: 4562
         y: 391
       selected: false
       sourcePosition: right
@@ -8550,10 +8743,10 @@ workflow:
       height: 54
       id: '17469682833511'
       position:
-        x: 4575
+        x: 4864
         y: 391
       positionAbsolute:
-        x: 4575
+        x: 4864
         y: 391
       selected: false
       sourcePosition: right
@@ -8607,10 +8800,10 @@ workflow:
       height: 54
       id: '17469682833512'
       position:
-        x: 4878
+        x: 5166
         y: 849
       positionAbsolute:
-        x: 4878
+        x: 5166
         y: 849
       selected: false
       sourcePosition: right
@@ -8753,10 +8946,10 @@ workflow:
       height: 54
       id: '17469682833513'
       position:
-        x: 4272
+        x: 4562
         y: 299
       positionAbsolute:
-        x: 4272
+        x: 4562
         y: 299
       selected: false
       sourcePosition: right
@@ -8810,10 +9003,10 @@ workflow:
       height: 54
       id: '17469682833514'
       position:
-        x: 4575
+        x: 4864
         y: 299
       positionAbsolute:
-        x: 4575
+        x: 4864
         y: 299
       selected: false
       sourcePosition: right
@@ -8867,10 +9060,10 @@ workflow:
       height: 54
       id: '17469682833515'
       position:
-        x: 4878
+        x: 5166
         y: 757
       positionAbsolute:
-        x: 4878
+        x: 5166
         y: 757
       selected: false
       sourcePosition: right
@@ -8897,10 +9090,10 @@ workflow:
       height: 126
       id: '1746968293209'
       position:
-        x: 3363
+        x: 3656
         y: 739
       positionAbsolute:
-        x: 3363
+        x: 3656
         y: 739
       selected: false
       sourcePosition: right
@@ -8916,8 +9109,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -8950,13 +9143,13 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17469683697070'
       position:
-        x: 5181
+        x: 5468
         y: 757
       positionAbsolute:
-        x: 5181
+        x: 5468
         y: 757
       selected: false
       sourcePosition: right
@@ -8972,8 +9165,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -9006,13 +9199,13 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17469686621940'
       position:
-        x: 5181
+        x: 5468
         y: 941
       positionAbsolute:
-        x: 5181
+        x: 5468
         y: 941
       selected: false
       sourcePosition: right
@@ -9048,11 +9241,11 @@ workflow:
       height: 54
       id: '1747206482765'
       position:
-        x: 4878
-        y: 2810
+        x: 5166
+        y: 2853
       positionAbsolute:
-        x: 4878
-        y: 2810
+        x: 5166
+        y: 2853
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9165,10 +9358,10 @@ workflow:
       height: 54
       id: '1747274324343'
       position:
-        x: 4878
+        x: 5166
         y: 665
       positionAbsolute:
-        x: 4878
+        x: 5166
         y: 665
       selected: false
       sourcePosition: right
@@ -9184,8 +9377,8 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: deepseek-chat
-          provider: langgenius/deepseek/deepseek
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
           role: system
@@ -9212,13 +9405,13 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 90
+      height: 96
       id: '17472781853800'
       position:
-        x: 5181
+        x: 5468
         y: 519
       positionAbsolute:
-        x: 5181
+        x: 5468
         y: 519
       selected: false
       sourcePosition: right
@@ -9245,11 +9438,11 @@ workflow:
       height: 126
       id: '1747640541034'
       position:
-        x: 3666
-        y: 2388
+        x: 3958
+        y: 2376
       positionAbsolute:
-        x: 3666
-        y: 2388
+        x: 3958
+        y: 2376
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9275,11 +9468,11 @@ workflow:
       height: 126
       id: '17476425548280'
       position:
-        x: 3666
-        y: 2552
+        x: 3958
+        y: 2540
       positionAbsolute:
-        x: 3666
-        y: 2552
+        x: 3958
+        y: 2540
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9420,11 +9613,11 @@ workflow:
       height: 54
       id: '1747645046499'
       position:
-        x: 3363
-        y: 2606
+        x: 3656
+        y: 2594
       positionAbsolute:
-        x: 3363
-        y: 2606
+        x: 3656
+        y: 2594
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9565,11 +9758,11 @@ workflow:
       height: 54
       id: '1747645082213'
       position:
-        x: 3363
-        y: 2442
+        x: 3656
+        y: 2430
       positionAbsolute:
-        x: 3363
-        y: 2442
+        x: 3656
+        y: 2430
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9738,17 +9931,787 @@ workflow:
       height: 54
       id: '1747646145340'
       position:
-        x: 3969
-        y: 2686
+        x: 4260
+        y: 2726
       positionAbsolute:
-        x: 3969
-        y: 2686
+        x: 4260
+        y: 2726
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        cases:
+        - case_id: 'true'
+          conditions:
+          - comparison_operator: contains
+            id: 744c46dd-2acd-4bc0-93e9-270e1a558d0d
+            value: 内存
+            varType: string
+            variable_selector:
+            - '1744959389144'
+            - alertName
+          id: 'true'
+          logical_operator: and
+        desc: ''
+        selected: false
+        title: IF/ELSE 10
+        type: if-else
+      height: 126
+      id: '1750387980645'
+      position:
+        x: 2146
+        y: 2558
+      positionAbsolute:
+        x: 2146
+        y: 2558
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: reportType
+            zh_Hans: 报告类型
+          label:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: reportType
+            zh_Hans: 报告类型
+          llm_description: alert report type
+          max: null
+          min: null
+          name: reportType
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportType
+            ja_JP: reportType
+            pt_BR: tags
+            zh_Hans: 报告标签（用于检索）
+          label:
+            en_US: tags
+            ja_JP: tags
+            pt_BR: tags
+            zh_Hans: 报告标签（用于检索）
+          llm_description: alert report tags
+          max: null
+          min: null
+          name: tags
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: overview
+            ja_JP: overview
+            pt_BR: overview
+            zh_Hans: 告警事件总览
+          label:
+            en_US: overview
+            ja_JP: overview
+            pt_BR: overview
+            zh_Hans: 告警事件总览
+          llm_description: overview
+          max: null
+          min: null
+          name: overview
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: topology
+            ja_JP: topology
+            pt_BR: topology
+            zh_Hans: 报告类型
+          label:
+            en_US: topology
+            ja_JP: topology
+            pt_BR: topology
+            zh_Hans: 拓扑数据
+          llm_description: topology data
+          max: null
+          min: null
+          name: topology
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: rootCauseAnalysis
+            ja_JP: rootCauseAnalysis
+            pt_BR: rootCauseAnalysis
+            zh_Hans: 根因分析结论
+          label:
+            en_US: rootCauseAnalysis
+            ja_JP: rootCauseAnalysis
+            pt_BR: rootCauseAnalysis
+            zh_Hans: 根因分析结论
+          llm_description: rootCauseAnalysis
+          max: null
+          min: null
+          name: rootCauseAnalysis
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: suggest
+            ja_JP: suggest
+            pt_BR: suggest
+            zh_Hans: 可行动方向建议
+          label:
+            en_US: suggest
+            ja_JP: suggest
+            pt_BR: suggest
+            zh_Hans: 可行动方向建议
+          llm_description: suggest
+          max: null
+          min: null
+          name: suggest
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: evidence
+            ja_JP: evidence
+            pt_BR: evidence
+            zh_Hans: 根因分析结论
+          label:
+            en_US: evidence
+            ja_JP: evidence
+            pt_BR: evidence
+            zh_Hans: 验证数据
+          llm_description: evidence
+          max: null
+          min: null
+          name: evidence
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        params:
+          evidence: ''
+          overview: ''
+          reportType: ''
+          rootCauseAnalysis: ''
+          suggest: ''
+          tags: ''
+          topology: ''
+        provider_id: apo_analysis
+        provider_name: apo_analysis
+        provider_type: builtin
+        selected: false
+        title: 生成告警分析报告
+        tool_configurations: {}
+        tool_label: 生成告警分析报告
+        tool_name: Generate alert analysis report
+        tool_parameters:
+          evidence:
+            type: mixed
+            value: '{"evidence": []}'
+          overview:
+            type: mixed
+            value: '{{#1750988484023.result#}}'
+          reportType:
+            type: mixed
+            value: infra
+          rootCauseAnalysis:
+            type: mixed
+            value: '{}'
+          suggest:
+            type: mixed
+            value: '{{#1750990570740.result#}}'
+          tags:
+            type: mixed
+            value: '{{#1750988333220.result#}}'
+          topology:
+            type: mixed
+            value: '{}'
+        type: tool
+      height: 54
+      id: '1750988315593'
+      position:
+        x: 7284
+        y: 1662
+      positionAbsolute:
+        x: 7284
+        y: 1662
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\ndef main(alertEventId: str) -> dict:\n    data = {\n        \"alertEventId\"\
+          : alertEventId\n    }\n    return {\n        \"result\": json.dumps(data),\n\
+          \    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 生成报告标签
+        type: code
+        variables:
+        - value_selector:
+          - '1744959389144'
+          - alertEventId
+          variable: alertEventId
+      height: 54
+      id: '1750988333220'
+      position:
+        x: 6982
+        y: 1754
+      positionAbsolute:
+        x: 6982
+        y: 1754
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "\n\ndef main(timestamp: int, reason: str, pod: str, node: str, pid:\
+          \ str, containerId: str, service: str,detail: str) -> dict:\n    data =\
+          \ {\n        \"timestamp\": timestamp,\n        \"detail\": detail,\n  \
+          \      \"reason\": reason,\n        \"tags\": {\n            \"service\"\
+          : service,\n            \"pod\": pod,\n            \"nodeName\": node,\n\
+          \            \"pid\": pid,\n            \"containerId\": containerId\n \
+          \       }\n    }\n    return {\n        \"result\": json.dumps(data),\n\
+          \    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 报告总览
+        type: code
+        variables:
+        - value_selector:
+          - '1743576019537'
+          - endTime
+          variable: timestamp
+        - value_selector:
+          - '1750988845336'
+          - text
+          variable: reason
+        - value_selector:
+          - '1744959389144'
+          - pod
+          variable: pod
+        - value_selector:
+          - '1744959389144'
+          - nodeName
+          variable: node
+        - value_selector:
+          - '1744959389144'
+          - pid
+          variable: pid
+        - value_selector:
+          - '1744959389144'
+          - containerId
+          variable: containerId
+        - value_selector:
+          - '1744959389144'
+          - service
+          variable: service
+        - value_selector:
+          - '1750988869166'
+          - text
+          variable: detail
+      height: 54
+      id: '1750988484023'
+      position:
+        x: 6982
+        y: 1662
+      positionAbsolute:
+        x: 6982
+        y: 1662
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: af87b10f-e6a5-41a3-876c-871803048be1
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: cb955092-396e-4262-bb69-f60546511ad4
+          role: user
+          text: "#目的\n根据应用的结论生成根因方向的结论\n#结论数据\n{{#1743850218410.output#}}\n# 时间\n\
+            {{#1743576019537.endTime#}}\n#格式模版参考\n告警报事件结论 \n**事件概述**：\n\n\U0001F6A8\
+            \ 基础设施xxx变化：15%的请求超过70毫秒，持续5分钟\n\U0001F4CA 数据xx：共128个，90%异常\n**问题分析**\n\
+            \n\U0001F552 指标显示xxx\n \U0001F310 显示xxx可能存在xxxx\n**解决措施**：\n\n\U0001F6E0\
+            ️ 执行xxx\n\U0001F527 检查xxx\n**指标数据**：\n\n⏱️ xx异常\n#输出格式\n格式参考模版，注意换行和空格，确保文本美观输出，简单易懂(使用MarkDown格式的文本)，且不要有其他输出"
+        selected: false
+        title: 结构化结论
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750988845336'
+      position:
+        x: 6680
+        y: 1662
+      positionAbsolute:
+        x: 6680
+        y: 1662
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 2fff5ede-e66b-4051-a411-920d1d021f10
+          role: system
+          text: 你是一个可观测性领域的智能助手，帮助用户解决问题
+        - id: e2fbc5b9-89bb-4b6b-8002-c35aeed18594
+          role: user
+          text: "#目的\n根据应用的结论生成当前情况的描述\n使用结论内的数据，回答简洁易懂\n#结论数据\n{{#1743850218410.output#}}\n\
+            # 时间\n{{#1743576019537.endTime#}}\n#格式模版参考\n告警报事件结论 \n**事件概述**：\n当前告警事件为XXXX\
+            \ (简洁，不要有其他内容)\n**问题分析**\n初步分析是XXX方向（通过日志内容总结），不要有其他内容，给出方向即可\n**解决措施**：\n\
+            - 执行XXXX命令（必须和故障方向有关）\n\n#输出格式\n格式参考模版，注意换行和空格，确保文本美观输出，简单易懂(使用MarkDown格式的文本)，且不要有其他输出"
+        selected: false
+        title: 总结
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750988869166'
+      position:
+        x: 6377
+        y: 1663
+      positionAbsolute:
+        x: 6377
+        y: 1663
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 04f72736-b848-4385-819d-5795c4b28ad2
+          role: system
+          text: 你是一个可观测领域的智能体，需要帮助用户解决问题
+        - id: bcbe26b2-893a-4c88-994e-2a8228a69b84
+          role: user
+          text: "#目的\n生成建议用户的行动建议\n如执行命令，或者找xxx排除问题\n#结论数据\n{{#1743850218410.output#}}\n\
+            \n#格式模版\n```json\n{\"suggest\": [\n        {\n            \"action\":\
+            \ \"Add index to payment transaction table.\",\n            \"level\"\
+            : \"high\"\n        },\n        {\n            \"action\": \"Scale up\
+            \ database node CPU resources.\",\n            \"level\": \"medium\"\n\
+            \        }\n    ] }\n```\n#输出格式\naction建议为中文\njson格式数据，格式参数模版，不要有其他输出"
+        selected: false
+        title: 行动建议
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750990566608'
+      position:
+        x: 6680
+        y: 1458
+      positionAbsolute:
+        x: 6680
+        y: 1458
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\ndef main(raw_data: str) -> dict:\n    pattern = r'```json\\\
+          n(.*?)\\n```'\n    match = re.search(pattern, raw_data, re.DOTALL)\n\n \
+          \   json_str = match.group(1)\n    rootcause = json.loads(json_str)\n  \
+          \  return {\n        \"result\": json.dumps(rootcause),\n    }"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 行动建议JSON
+        type: code
+        variables:
+        - value_selector:
+          - '1750990566608'
+          - text
+          variable: raw_data
+      height: 54
+      id: '1750990570740'
+      position:
+        x: 6982
+        y: 1458
+      positionAbsolute:
+        x: 6982
+        y: 1458
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: /models/qwen2.5-32B
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 7b7ab7e9-d22f-41b1-bf50-2db3aacbaf1e
+          role: system
+          text: ''
+        - id: cd6a570d-f5e0-4f56-8fd5-937563838009
+          role: user
+          text: "#目的\n从故障结论和告警事件中提取故障方向\n# 注意\n根据结论的内容划分故障方向\n1 如果网络链路rtt异常，给出网络异常\n\
+            2 磁盘，内存等异常 给出资源类问题 \n#结论数据\n{{#1743850218410.output#}}\n#告警事件描述\n{{#1744959389144.alertName#}}\n\
+            #输出内容\n故障方向，只输出四个字就好 （如网络方向，基础设施资源类异常等）"
+        selected: false
+        title: LLM 13
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 96
+      id: '1750995788076'
+      position:
+        x: 7890
+        y: 1662
+      positionAbsolute:
+        x: 7890
+        y: 1662
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        is_team_authorization: true
+        output_schema: null
+        paramSchemas:
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: alertEventId
+            ja_JP: alertEventId
+            pt_BR: alertEventId
+            zh_Hans: 报告类型
+          label:
+            en_US: alertEventId
+            ja_JP: alertEventId
+            pt_BR: alertEventId
+            zh_Hans: 告警事件ID
+          llm_description: alertEventId
+          max: null
+          min: null
+          name: alertEventId
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: reportText
+            ja_JP: reportText
+            pt_BR: reportText
+            zh_Hans: 报告简要文本
+          label:
+            en_US: reportText
+            ja_JP: reportText
+            pt_BR: reportText
+            zh_Hans: 报告简要文本
+          llm_description: reportText
+          max: null
+          min: null
+          name: reportText
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: frontPrefix
+            ja_JP: frontPrefix
+            pt_BR: frontPrefix
+            zh_Hans: 报告访问地址
+          label:
+            en_US: frontPrefix
+            ja_JP: frontPrefix
+            pt_BR: frontPrefix
+            zh_Hans: 报告访问地址
+          llm_description: frontPrefix
+          max: null
+          min: null
+          name: frontPrefix
+          options: []
+          placeholder: null
+          precision: null
+          required: false
+          scope: null
+          template: null
+          type: string
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: Start timestamp in microseconds
+            ja_JP: Start timestamp in microseconds
+            pt_BR: Start timestamp in microseconds
+            zh_Hans: 查询开始时间（微秒）
+          label:
+            en_US: Start Time
+            ja_JP: Start Time
+            pt_BR: Start Time
+            zh_Hans: 开始时间
+          llm_description: Microsecond timestamp for start time
+          max: null
+          min: null
+          name: startTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        - auto_generate: null
+          default: null
+          form: llm
+          human_description:
+            en_US: End timestamp in microseconds
+            ja_JP: End timestamp in microseconds
+            pt_BR: End timestamp in microseconds
+            zh_Hans: 查询结束时间（微秒）
+          label:
+            en_US: End Time
+            ja_JP: End Time
+            pt_BR: End Time
+            zh_Hans: 结束时间
+          llm_description: Microsecond timestamp for end time
+          max: null
+          min: null
+          name: endTime
+          options: []
+          placeholder: null
+          precision: null
+          required: true
+          scope: null
+          template: null
+          type: number
+        params:
+          alertEventId: ''
+          endTime: ''
+          frontPrefix: ''
+          reportText: ''
+          startTime: ''
+        provider_id: apo_analysis
+        provider_name: apo_analysis
+        provider_type: builtin
+        selected: false
+        title: 获取告警分析报告链接
+        tool_configurations: {}
+        tool_label: 获取告警分析报告链接
+        tool_name: get alert report url
+        tool_parameters:
+          alertEventId:
+            type: mixed
+            value: '{{#1744959389144.alertEventId#}}'
+          endTime:
+            type: variable
+            value:
+            - '1743576019537'
+            - endTime
+          frontPrefix:
+            type: mixed
+            value: ''
+          reportText:
+            type: mixed
+            value: 当前基础设施资源存在问题\n详细报告内容\n
+          startTime:
+            type: variable
+            value:
+            - '1743576019537'
+            - startTime
+        type: tool
+      height: 54
+      id: '1751602121596'
+      position:
+        x: 7586
+        y: 1662
+      positionAbsolute:
+        x: 7586
+        y: 1662
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        cases:
+        - case_id: 'true'
+          conditions:
+          - comparison_operator: contains
+            id: 8acc7071-5619-45e7-895a-6d0bfd3d3b7d
+            value: ce
+            varType: string
+            variable_selector:
+            - '1743576019537'
+            - edition
+          id: 'true'
+          logical_operator: and
+        desc: ''
+        selected: false
+        title: report
+        type: if-else
+      height: 126
+      id: '1751602227575'
+      position:
+        x: 6072
+        y: 1458
+      positionAbsolute:
+        x: 6072
+        y: 1458
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        outputs:
+        - value_selector:
+          - '1743850218410'
+          - output
+          variable: text
+        selected: false
+        title: 结束 6
+        type: end
+      height: 90
+      id: '1751602318456'
+      position:
+        x: 6398.3677454776225
+        y: 1362.661015208872
+      positionAbsolute:
+        x: 6398.3677454776225
+        y: 1362.661015208872
       selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
       width: 244
     viewport:
-      x: -1863.509780190645
-      y: -525.5472978057951
-      zoom: 0.4211620968711879
+      x: 295.4153431252935
+      y: 57.468265580007824
+      zoom: 0.581194023912935

--- a/api/init_data/workflows/zh/资源告警分析.yml
+++ b/api/init_data/workflows/zh/资源告警分析.yml
@@ -1757,10 +1757,43 @@ workflow:
       targetHandle: target
       type: custom
       zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: if-else
+        targetType: llm
+      id: 1751602227575-false-1751617706952-target
+      source: '1751602227575'
+      sourceHandle: 'false'
+      target: '1751617706952'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: llm
+        targetType: code
+      id: 1751617706952-source-1751617715636-target
+      source: '1751617706952'
+      sourceHandle: source
+      target: '1751617715636'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        sourceType: code
+        targetType: tool
+      id: 1751617715636-source-1750988315593-target
+      source: '1751617715636'
+      sourceHandle: source
+      target: '1750988315593'
+      targetHandle: target
+      type: custom
+      zIndex: 0
     nodes:
     - data:
         desc: ''
-        selected: true
+        selected: false
         title: 开始
         type: start
         variables:
@@ -1802,7 +1835,7 @@ workflow:
       positionAbsolute:
         x: 30
         y: 299
-      selected: true
+      selected: false
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -1838,7 +1871,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1744959389144'
@@ -1849,7 +1882,7 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 498
+      height: 492
       id: '1743577315409'
       position:
         x: 2448
@@ -3469,7 +3502,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -3513,7 +3546,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1743673613633'
       position:
         x: 5468
@@ -3632,7 +3665,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1746777077402'
@@ -3643,7 +3676,7 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 174
+      height: 168
       id: '1743846657026'
       position:
         x: 3656
@@ -4822,7 +4855,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -4856,7 +4889,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17438483761510'
       position:
         x: 5468
@@ -4909,7 +4942,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -4943,7 +4976,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17438490633890'
       position:
         x: 5468
@@ -5129,7 +5162,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '1743849441196'
@@ -5140,7 +5173,7 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 174
+      height: 168
       id: '17438494733730'
       position:
         x: 4260
@@ -5332,7 +5365,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -5366,7 +5399,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17438498987710'
       position:
         x: 5468
@@ -5514,7 +5547,7 @@ workflow:
             - endTime
           node:
             type: mixed
-            value: '{{#1744959389144.instanceName#}}'
+            value: '{{#1743576019537.nodeName#}}'
           startTime:
             type: variable
             value:
@@ -6601,8 +6634,8 @@ workflow:
             value: ''
             varType: string
             variable_selector:
-            - '1744959389144'
-            - instanceName
+            - '1743576019537'
+            - nodeName
           id: 'true'
           logical_operator: and
         desc: ''
@@ -6937,7 +6970,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         query_variable_selector:
         - '17467775030610'
@@ -6948,7 +6981,7 @@ workflow:
         type: question-classifier
         vision:
           enabled: false
-      height: 174
+      height: 168
       id: '17467775030611'
       position:
         x: 4260
@@ -7353,7 +7386,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -7387,7 +7420,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17467776423972'
       position:
         x: 5468
@@ -7579,7 +7612,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -7613,7 +7646,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17467776423974'
       position:
         x: 5468
@@ -8020,11 +8053,11 @@ workflow:
       height: 126
       id: '1746967296261'
       position:
-        x: 3052
-        y: 905
+        x: 3073.968248490347
+        y: 896.550673657559
       positionAbsolute:
-        x: 3052
-        y: 905
+        x: 3073.968248490347
+        y: 896.550673657559
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9109,7 +9142,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -9143,7 +9176,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17469683697070'
       position:
         x: 5468
@@ -9165,7 +9198,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -9199,7 +9232,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17469686621940'
       position:
         x: 5468
@@ -9348,7 +9381,7 @@ workflow:
             - endTime
           node:
             type: mixed
-            value: '{{#1744959389144.instanceName#}}'
+            value: '{{#1743576019537.nodeName#}}'
           startTime:
             type: variable
             value:
@@ -9358,11 +9391,11 @@ workflow:
       height: 54
       id: '1747274324343'
       position:
-        x: 5166
-        y: 665
+        x: 5201.109522220137
+        y: 639.4658020217188
       positionAbsolute:
-        x: 5166
-        y: 665
+        x: 5201.109522220137
+        y: 639.4658020217188
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -9377,7 +9410,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 5426b9f0-37c8-45b7-9faa-49695110dc7d
@@ -9405,7 +9438,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '17472781853800'
       position:
         x: 5468
@@ -10155,7 +10188,7 @@ workflow:
         provider_id: apo_analysis
         provider_name: apo_analysis
         provider_type: builtin
-        selected: false
+        selected: true
         title: 生成告警分析报告
         tool_configurations: {}
         tool_label: 生成告警分析报告
@@ -10172,7 +10205,7 @@ workflow:
             value: infra
           rootCauseAnalysis:
             type: mixed
-            value: '{}'
+            value: '{{#1751617706952.text#}}'
           suggest:
             type: mixed
             value: '{{#1750990570740.result#}}'
@@ -10191,7 +10224,7 @@ workflow:
       positionAbsolute:
         x: 7284
         y: 1662
-      selected: false
+      selected: true
       sourcePosition: right
       targetPosition: left
       type: custom
@@ -10300,7 +10333,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: af87b10f-e6a5-41a3-876c-871803048be1
@@ -10319,7 +10352,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1750988845336'
       position:
         x: 6680
@@ -10341,7 +10374,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 2fff5ede-e66b-4051-a411-920d1d021f10
@@ -10359,7 +10392,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1750988869166'
       position:
         x: 6377
@@ -10381,7 +10414,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 04f72736-b848-4385-819d-5795c4b28ad2
@@ -10401,7 +10434,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1750990566608'
       position:
         x: 6680
@@ -10455,7 +10488,7 @@ workflow:
           completion_params:
             temperature: 0.7
           mode: chat
-          name: /models/qwen2.5-32B
+          name: deepseek-chat
           provider: langgenius/openai_api_compatible/openai_api_compatible
         prompt_template:
         - id: 7b7ab7e9-d22f-41b1-bf50-2db3aacbaf1e
@@ -10472,7 +10505,7 @@ workflow:
         variables: []
         vision:
           enabled: false
-      height: 96
+      height: 90
       id: '1750995788076'
       position:
         x: 7890
@@ -10711,7 +10744,92 @@ workflow:
       targetPosition: left
       type: custom
       width: 244
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        desc: ''
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: deepseek-chat
+          provider: langgenius/openai_api_compatible/openai_api_compatible
+        prompt_template:
+        - id: 47524d65-b967-4f09-a1f9-f9f375f7c1f8
+          role: system
+          text: 你是一个可观测性领域的智能助手
+        - id: f86d541a-f77c-4b50-9f50-f88ab6a67a8e
+          role: user
+          text: "#目的\n根据应用的日志结论生成日志根因方向的结论\n#结论数据\n{{#1743850218410.output#}}\n# 注意\n\
+            type为故障方向\n1网络异常（net）,磁盘异常（disk）,文件描述符使用（file）, CPU占用（cpu）， 内存使用（memory）\n\
+            每个方向直给一个结论即可，不要出现重复\n主要根因方向必须和major结论保持一致，不要不统一\n2且必须给一个有问题的方向(level为major)\n\
+            3 列表必须按照等级排序level从高到低维（major,minor,normal）\n4 cause内容只能为网络异常,磁盘异常,文件描述符使用,\
+            \ CPU占用， 内存使用\n#格式模版\n```json\n{\n        \"cause\": \"主要原根因方向\",\n  \
+            \      \"other\": [\n            {\n                \"reason\": \"\",\n\
+            \                \"type\": \"net\",\n                \"level\": \"major/minor/normal\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"disk\",\n                \"level\": \"minor\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"file\",\n                \"level\": \"normal\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"cpu\",\n                \"level\": \"normal\"\
+            \n            },\n            {\n                \"reason\": \"\",\n \
+            \               \"type\": \"memory\",\n                \"level\": \"normal\"\
+            \n            }\n        ]\n    }\n```\n#输出格式\ntype只能为网络异常（net）,磁盘异常（disk）,文件描述符使用（file）,\
+            \ CPU占用（cpu）， 内存使用（memory）这几种，不要有其他内容\njson格式数据，格式参数模版，不要有其他输出"
+        selected: false
+        title: 根因方向
+        type: llm
+        variables: []
+        vision:
+          enabled: false
+      height: 90
+      id: '1751617706952'
+      position:
+        x: 6484.605732137941
+        y: 1554.9014271835003
+      positionAbsolute:
+        x: 6484.605732137941
+        y: 1554.9014271835003
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        code: "import re\ndef main(raw_data: str) -> dict:\n    pattern = r'```json\\\
+          n(.*?)\\n```'\n    match = re.search(pattern, raw_data, re.DOTALL)\n\n \
+          \   json_str = match.group(1)\n    rootcause = json.loads(json_str)\n  \
+          \  return {\n        \"result\": json.dumps(rootcause),\n    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: string
+        selected: false
+        title: 根因方向
+        type: code
+        variables:
+        - value_selector:
+          - '1751617706952'
+          - text
+          variable: raw_data
+      height: 54
+      id: '1751617715636'
+      position:
+        x: 6850.607787688614
+        y: 1565
+      positionAbsolute:
+        x: 6850.607787688614
+        y: 1565
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
     viewport:
-      x: 295.4153431252935
-      y: 57.468265580007824
-      zoom: 0.581194023912935
+      x: -4387.795490058535
+      y: -718.0004622031324
+      zoom: 0.7257823889922984

--- a/api/initializer/workflow.py
+++ b/api/initializer/workflow.py
@@ -161,13 +161,16 @@ def _adjust_workflows(language, account):
                 "api_token": "app-s8e5CusGAqNcjyTUbPCoJcu4"
             },
             "告警简单根因分析": {
-                "app_id": "a2d4d3aa-3401-4393-859e-df051bdd5cd1"
+                "app_id": "a2d4d3aa-3401-4393-859e-df051bdd5cd1",
+                "api_token": "app-JDtZH1DfQtQb1SjzC3as680C"
             },
             "可用性告警分析": {
-                "app_id": "40dea201-7aa4-4e27-865b-6ebeab91a0c3"
+                "app_id": "40dea201-7aa4-4e27-865b-6ebeab91a0c3",
+                "api_token": "app-LmlwNJaxmSWRCd2DCk6MhkDd"
             },
             "资源告警分析": {
-                "app_id": "f514d742-6043-498e-98f1-ab03cbcb0250"
+                "app_id": "f514d742-6043-498e-98f1-ab03cbcb0250",
+                "api_token": "app-aIEZTMcRkOicrNK1ZegT80wQ"
             }
         },
         "en-US": {


### PR DESCRIPTION
## Summary by Sourcery

Add a suite of new level-1 APO tools for dataplane queries and alert analysis, refactor root cause report fetching, and update workflow API tokens

New Features:
- Add multiple dataplane BuiltinTools for querying service topology, instances, endpoints, RED charts, and instance service names
- Introduce alert analysis tools for report generation and report URL retrieval with accompanying YAML metadata

Enhancements:
- Extract get_report helper from QueryRootCauseReportTool and add fallback request logic for additional results

Chores:
- Update API tokens for key alert analysis workflows in the initializer