### PR TITLE
refactor(tools): Refactoring parameter acquisition method

### DIFF
--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_cpu_total.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_cpu_total.py
@@ -19,13 +19,13 @@ class ClusterCpuTotalTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - CPU使用量 - Total',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_cpu_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_cpu_usage.py
@@ -19,13 +19,13 @@ class ClusterCpuUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 集群总CPU使用率 - Real Linux',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_cpu_usage_linux.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_cpu_usage_linux.py
@@ -19,7 +19,7 @@ class ClusterCpuUsageLinuxTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster', '.*')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_memory_total.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_memory_total.py
@@ -19,13 +19,13 @@ class ClusterMemoryTotalTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 内存使用量 - Total',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_memory_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_memory_usage.py
@@ -19,13 +19,13 @@ class ClusterMemoryUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 集群总内存使用率 - Real Linux',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_memory_usage_linux.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_memory_usage_linux.py
@@ -19,7 +19,7 @@ class ClusterMemoryUsageLinuxTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster', '.*')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_namespace_count.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_namespace_count.py
@@ -19,13 +19,13 @@ class ClusterNamespaceCountTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 命名空间数量',
             'params': {
-                **({'cadvisor_job_name': cadvisor_job_name} if cadvisor_job_name else {})
+                'cadvisor_job_name': cadvisor_job_name
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_network_linux_transmit_dropped_packets.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_network_linux_transmit_dropped_packets.py
@@ -19,13 +19,13 @@ class ClusterNetworkLinuxTransmitDroppedPacketsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 网络饱和 - 丢包数 - Linux Packets dropped (transmit)',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_network_receive_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_network_receive_bytes.py
@@ -19,7 +19,7 @@ class ClusterNetworkReceiveBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster', '.*')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_network_transmit_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_network_transmit_bytes.py
@@ -19,7 +19,7 @@ class ClusterNetworkTransmitBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster', '.*')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_count.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_count.py
@@ -19,13 +19,13 @@ class ClusterNodeCountTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 节点数',
             'params': {
-                **({'cadvisor_job_name': cadvisor_job_name} if cadvisor_job_name else {})
+                'cadvisor_job_name': cadvisor_job_name
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_cpu_throttle_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_cpu_throttle_seconds.py
@@ -19,13 +19,13 @@ class ClusterNodeCpuThrottleSecondsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点CPU限流时长',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_cpu_usage_linux.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_cpu_usage_linux.py
@@ -19,13 +19,13 @@ class ClusterNodeCpuUsageLinuxTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点CPU使用率 - Linux',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_loopback_receive_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_loopback_receive_bytes.py
@@ -19,13 +19,13 @@ class ClusterNodeLoopbackReceiveBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点的网络使用量(仅回环) - Received bytes in',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_loopback_transmit_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_loopback_transmit_bytes.py
@@ -19,13 +19,13 @@ class ClusterNodeLoopbackTransmitBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点的网络使用量(仅回环) - Transmitted bytes in',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_memory_usage_linux.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_memory_usage_linux.py
@@ -19,13 +19,13 @@ class ClusterNodeMemoryUsageLinuxTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点内存使用量 - Linux',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_receive_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_receive_bytes.py
@@ -19,13 +19,13 @@ class ClusterNodeNetworkReceiveBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点的网络使用量 - 接收',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_receive_excl_virtual_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_receive_excl_virtual_bytes.py
@@ -19,13 +19,13 @@ class ClusterNodeNetworkReceiveExclVirtualBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点的网络使用量(不含回环/虚拟设备) - Received bytes in',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_transmit_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_transmit_bytes.py
@@ -19,13 +19,13 @@ class ClusterNodeNetworkTransmitBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点的网络使用量 - 发送',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_transmit_excl_virtual_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_node_network_transmit_excl_virtual_bytes.py
@@ -19,13 +19,13 @@ class ClusterNodeNetworkTransmitExclVirtualBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 节点资源使用 - 节点的网络使用量(不含回环/虚拟设备) - Transmitted bytes in',
             'params': {
-                **({'cluster': cluster} if cluster else {})
+                'cluster': cluster
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_running_pod_count.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/cluster_running_pod_count.py
@@ -19,13 +19,13 @@ class ClusterRunningPodCountTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '集群总览 - 总览 - 运行的Pod数',
             'params': {
-                **({'cadvisor_job_name': cadvisor_job_name} if cadvisor_job_name else {})
+                'cadvisor_job_name': cadvisor_job_name
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_cfs.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_cfs.py
@@ -18,8 +18,8 @@ class SelectContainerCPUTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get("pod")
-        namespace = tool_parameters.get("namespace")
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_throttle_docker_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_throttle_docker_seconds.py
@@ -19,9 +19,9 @@ class ContainerCpuThrottleDockerSecondsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_usage_containerd.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_usage_containerd.py
@@ -19,17 +19,17 @@ class ContainerCpuUsageContainerdTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name')
-        namespace = tool_parameters.get('namespace')
-        pod = tool_parameters.get('pod')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {
             'metricName': '基础设施情况 - 容器CPU - 容器CPU使用率 - Containerd',
             'params': {
-                **({'cadvisor_job_name': cadvisor_job_name} if cadvisor_job_name else {}),
-                **({'namespace': namespace} if namespace else {}),
-                **({'pod': pod} if pod else {})
+                'cadvisor_job_name': cadvisor_job_name,
+                'namespace': namespace,
+                'pod': pod
             },
             'startTime': start_time,
             'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_usage_docker.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_usage_docker.py
@@ -19,9 +19,9 @@ class ContainerCpuUsageDockerTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_bytes_docker.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_bytes_docker.py
@@ -19,9 +19,9 @@ class ContainerDiskReadBytesDockerTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_ops_docker.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_ops_docker.py
@@ -19,9 +19,9 @@ class ContainerDiskReadOpsDockerTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_time_containerd_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_time_containerd_seconds.py
@@ -19,9 +19,9 @@ class ContainerDiskReadTimeContainerdSecondsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_write_bytes_docker.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_write_bytes_docker.py
@@ -19,9 +19,9 @@ class ContainerDiskWriteBytesDockerTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_write_ops_docker.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_write_ops_docker.py
@@ -19,9 +19,9 @@ class ContainerDiskWriteOpsDockerTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_write_time_containerd_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_write_time_containerd_seconds.py
@@ -19,9 +19,9 @@ class ContainerDiskWriteTimeContainerdSecondsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_memory_usage_containerd_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_memory_usage_containerd_bytes.py
@@ -19,9 +19,9 @@ class ContainerMemoryUsageContainerdBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_memory_usage_docker_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_memory_usage_docker_bytes.py
@@ -19,9 +19,9 @@ class ContainerMemoryUsageDockerBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_bandwidth_receive.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_bandwidth_receive.py
@@ -19,9 +19,9 @@ class ContainerNetworkBandwidthReceiveTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_bandwidth_transmit.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_bandwidth_transmit.py
@@ -19,9 +19,9 @@ class ContainerNetworkBandwidthTransmitTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_error_packets_receive.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_error_packets_receive.py
@@ -19,9 +19,9 @@ class ContainerNetworkErrorPacketsReceiveTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_error_packets_transmit.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_error_packets_transmit.py
@@ -19,9 +19,9 @@ class ContainerNetworkErrorPacketsTransmitTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_loss_receive.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_loss_receive.py
@@ -19,9 +19,9 @@ class ContainerNetworkPacketLossReceiveTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_loss_transmit.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_loss_transmit.py
@@ -19,9 +19,9 @@ class ContainerNetworkPacketLossTransmitTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_receive_rate.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_receive_rate.py
@@ -19,9 +19,9 @@ class ContainerNetworkPacketReceiveRateTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_transmit_rate.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_packet_transmit_rate.py
@@ -19,9 +19,9 @@ class ContainerNetworkPacketTransmitRateTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pod = tool_parameters.get('pod', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.py
@@ -18,11 +18,11 @@ class ContainerRTTTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get("pod") or ".*"
-        namespace = tool_parameters.get("namespace") or ".*"
-        node = tool_parameters.get("node") or ".*"
-        pid = tool_parameters.get("pid") or ".*"
-        container_id = tool_parameters.get("containerId") or ".*"
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_core_num.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_core_num.py
@@ -19,8 +19,8 @@ class HostCoreNumTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_core_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_core_usage.py
@@ -19,8 +19,8 @@ class HostCpuCoreUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_iowait.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_iowait.py
@@ -18,7 +18,7 @@ class HostCPUIoWaitRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_pressure.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_pressure.py
@@ -19,8 +19,8 @@ class HostCpuPressureTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_usage.py
@@ -19,7 +19,7 @@ class HostCpuUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_io.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_io.py
@@ -18,7 +18,7 @@ class HostDiskIOTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_read_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_read_bytes.py
@@ -18,7 +18,7 @@ class HostDiskReadBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_used.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_used.py
@@ -18,7 +18,7 @@ class HostDiskUsedTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_write_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_write_bytes.py
@@ -18,7 +18,7 @@ class HostDiskWriteBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_fd_open.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_fd_open.py
@@ -18,7 +18,7 @@ class HostCPUIoWaitRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         job = tool_parameters.get('job')

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_io_pressure.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_io_pressure.py
@@ -19,8 +19,8 @@ class HostIoPressureTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_memory_pressure.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_memory_pressure.py
@@ -19,8 +19,8 @@ class HostMemPressureTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_net_recv.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_net_recv.py
@@ -18,7 +18,7 @@ class HostCPUIoWaitRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_ram_total.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_ram_total.py
@@ -19,8 +19,8 @@ class HostRamTotalTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_ram_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_ram_usage.py
@@ -19,8 +19,8 @@ class HostRamUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_root_fs_total.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_root_fs_total.py
@@ -19,7 +19,7 @@ class HostRootFsTotalTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_root_fs_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_root_fs_usage.py
@@ -19,8 +19,8 @@ class HostRootFsUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_swap_total.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_swap_total.py
@@ -19,8 +19,8 @@ class HostSwapTotal(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_swap_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_swap_usage.py
@@ -19,8 +19,8 @@ class HostSwapUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_sys_load.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_sys_load.py
@@ -19,8 +19,8 @@ class HostSysLoad(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_sys_proc_busy.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_sys_proc_busy.py
@@ -19,8 +19,8 @@ class HostSysProcBusyTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_uptime.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_uptime.py
@@ -19,8 +19,8 @@ class HostUptimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/linux_network_dropped_packets_receive.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/linux_network_dropped_packets_receive.py
@@ -19,7 +19,7 @@ class LinuxNetworkDroppedPacketsReceiveTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cluster = tool_parameters.get('cluster', '.*')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/log_error_level_count.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/log_error_level_count.py
@@ -19,9 +19,9 @@ class LogErrorLevelCountTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod_name = tool_parameters.get('pod_name', '.*')
-        namespace = tool_parameters.get('namespace', '.*')
-        pid = tool_parameters.get('pid', '.*')
+        pod_name = APOUtils.get_and_fill_param(tool_parameters, 'pod_name')
+        namespace = APOUtils.get_and_fill_param(tool_parameters, 'namespace')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_throttle_containerd_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_throttle_containerd_seconds.py
@@ -19,8 +19,8 @@ class NamespaceCpuThrottleContainerdSecondsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_throttle_docker_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_throttle_docker_seconds.py
@@ -19,8 +19,8 @@ class NamespaceCpuThrottleDockerSecondsTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_usage_containerd.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_usage_containerd.py
@@ -19,8 +19,8 @@ class NamespaceCpuUsageContainerdTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_usage_docker.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_cpu_usage_docker.py
@@ -19,8 +19,8 @@ class NamespaceCpuUsageDockerTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_memory_usage_containerd_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_memory_usage_containerd_bytes.py
@@ -19,8 +19,8 @@ class NamespaceMemoryUsageContainerdBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_memory_usage_docker_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_memory_usage_docker_bytes.py
@@ -19,8 +19,8 @@ class NamespaceMemoryUsageDockerBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_network_receive_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_network_receive_bytes.py
@@ -19,8 +19,8 @@ class NamespaceNetworkReceiveBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_network_send_bytes.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/namespace_network_send_bytes.py
@@ -19,8 +19,8 @@ class NamespaceNetworkSendBytesTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        cadvisor_job_name = tool_parameters.get('cadvisor_job_name', '.*')
-        cluster = tool_parameters.get('cluster', '.*')
+        cadvisor_job_name = APOUtils.get_and_fill_param(tool_parameters, 'cadvisor_job_name')
+        cluster = APOUtils.get_and_fill_param(tool_parameters, 'cluster')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_io_utilization.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_io_utilization.py
@@ -19,8 +19,8 @@ class NodeDiskIoUtilizationTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        job = tool_parameters.get('job', '.*')
-        node = tool_parameters.get('node', '.*')
+        job = APOUtils.get_and_fill_param(tool_parameters, 'job')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         if not job:

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_size.py
@@ -19,13 +19,13 @@ class NodeDiskRootSizeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get('node', '.*')
+        node = APOUtils.get_and_fill_param(tool_parameters, 'node')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         step = APOUtils.get_step(start_time=start_time, end_time=end_time)
         interval = APOUtils.vec_from_duration(step * 1000)
         query = f"""
-        node_filesystem_size_bytes{{instance_name="{node}", mountpoint="/"}}[{interval}]
+        node_filesystem_size_bytes{{instance_name=~"{node}", mountpoint="/"}}[{interval}]
         """
         resp = requests.get(
             dify_config.APO_VM_URL + "/prometheus/api/v1/query_range",

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_monitor.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_monitor.py
@@ -21,12 +21,12 @@ class OriginxServiceMonitorTool(BuiltinTool):
         node_name = tool_parameters.get("node_name")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        pid = tool_parameters.get("pid")
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
         params = {
           'metricName': 'Thread Polaris Metrics - 北极星指标（进程） - 节点上被监控的服务列表',
           'params': {
             "node_name": node_name,
-            **({'pid': pid} if pid else {})
+            'pid': pid
           },
           'startTime': start_time,
           'endTime': end_time,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_red_avg_resp.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_red_avg_resp.py
@@ -18,8 +18,8 @@ class OriginxServiceRedAvgRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        service_name = tool_parameters.get("service_name")
-        content_key = tool_parameters.get("content_key")
+        service_name = APOUtils.get_and_fill_param(tool_parameters, "service_name")
+        content_key = APOUtils.get_and_fill_param(tool_parameters, 'content_key')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_red_resp_ok.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_red_resp_ok.py
@@ -18,8 +18,8 @@ class OriginxServiceRedRespOkTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        service_name = tool_parameters.get("service_name")
-        content_key = tool_parameters.get("content_key")
+        service_name = APOUtils.get_and_fill_param(tool_parameters, "service_name")
+        content_key = APOUtils.get_and_fill_param(tool_parameters, 'content_key')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/polar_process_all_resp.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/polar_process_all_resp.py
@@ -18,7 +18,7 @@ class PolarProcessAllRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get("pod")
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/polaris_time_by_pid.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/polaris_time_by_pid.py
@@ -19,10 +19,10 @@ class PolarisTimeByPidTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pid = tool_parameters.get('pid', '.*')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        resource_type = tool_parameters.get('type', '.*')
+        resource_type = APOUtils.get_and_fill_param(tool_parameters, 'type')
         step = APOUtils.get_step(start_time=start_time, end_time=end_time)
         interval = APOUtils.vec_from_duration(step * 1000)
         if len(pid) == 0:

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_cpu_usage.py
@@ -19,11 +19,10 @@ class ProcessCPUUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        group_name = tool_parameters.get('groupName', '.*') or '.*'
-
+        group_name = APOUtils.get_and_fill_param(tool_parameters, "groupName")
+        instance_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        instance_name = tool_parameters.get('nodeName', '.*') or ".*"
 
 
         step = APOUtils.get_step(start_time=start_time, end_time=end_time)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/process_memory_usage.py
@@ -19,12 +19,10 @@ class ProcessMemoryUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        group_name = tool_parameters.get('groupName', '.*') or '.*'
-
+        group_name = APOUtils.get_and_fill_param(tool_parameters, 'groupName')
+        instance_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        instance_name = tool_parameters.get('nodeName', '.*') or ".*"
-
 
         query = f"""
         namedprocess_namegroup_memory_bytes{{groupname=~"{group_name}", instance_name=~"{instance_name}"}} / 

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisEpollTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        pid = tool_parameters.get('pid', '')
-        container_id = tool_parameters.get('containerId', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pid': pid if pid != '' else '.*',
-            'pod': pod if pod != '' else '.*',
+            'node_name': node_name,
+            'container_id': container_id,
+            'pid': pid,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_file_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_file_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisFileTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        pid = tool_parameters.get('pid', '')
-        container_id = tool_parameters.get('containerId', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pid': pid if pid != '' else '.*',
-            'pod': pod if pod != '' else '.*',
+            'node_name': node_name,
+            'container_id': container_id,
+            'pid': pid,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_futex_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_futex_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisFutexTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        pid = tool_parameters.get('pid', '')
-        container_id = tool_parameters.get('containerId', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pid': pid if pid != '' else '.*',
-            'pod': pod if pod != '' else '.*',
+            'node_name': node_name,
+            'container_id': container_id,
+            'pid': pid,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_idle_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_idle_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisIdleTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        container_id = tool_parameters.get('containerId', '')
-        pid = tool_parameters.get('pid', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pid': pid if pid != '' else '.*',
-            'pod': pod if pod != '' else '.*',
+            'node_name': node_name,
+            'container_id': container_id,
+            'pid': pid,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisNetTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '.*')
-        node_name = tool_parameters.get('nodeName', '.*')
-        pid = tool_parameters.get('pid', '.*')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         container_id = tool_parameters.get('containerId', '.*')
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'pid': pid if pid != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pod': pod if pod != '' else '.*',
+            'node_name': node_name,
+            'pid': pid,
+            'container_id': container_id,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisOncpuTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        pid = tool_parameters.get('pid', '')
-        container_id = tool_parameters.get('containerId', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pid': pid if pid != '' else '.*',
-            'pod': pod if pod != '' else '.*',
+            'node_name': node_name,
+            'container_id': container_id,
+            'pid': pid,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_other_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_other_time.py
@@ -19,18 +19,18 @@ class ThreadPolarisOtherTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        pid = tool_parameters.get('pid', '')
-        container_id = tool_parameters.get('containerId', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
         metric_params = {
-            'node_name': node_name if node_name != '' else '.*',
-            'container_id': container_id if container_id != '' else '.*',
-            'pid': pid if pid else '.*',
-            'pod': pod if pod else '.*',
+            'node_name': node_name,
+            'container_id': container_id,
+            'pid': pid,
+            'pod': pod,
         }
 
         params = {

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_runqueue_time.py
@@ -19,10 +19,10 @@ class ThreadPolarisRunqueueTimeTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get('pod', '')
-        node_name = tool_parameters.get('nodeName', '')
-        pid = tool_parameters.get('pid', '')
-        container_id = tool_parameters.get('containerId', '')
+        pod = APOUtils.get_and_fill_param(tool_parameters, 'pod')
+        node_name = APOUtils.get_and_fill_param(tool_parameters, 'nodeName')
+        pid = APOUtils.get_and_fill_param(tool_parameters, 'pid')
+        container_id = APOUtils.get_and_fill_param(tool_parameters, 'containerId')
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 

--- a/api/libs/apo_utils.py
+++ b/api/libs/apo_utils.py
@@ -74,3 +74,20 @@ class APOUtils:
             step = f"{step_hours}h"
 
         return step
+    
+    @staticmethod
+    def get_and_fill_param(params: dict, key: str) -> str:
+        """
+        Gets a key's value from params. If the value is 'truthy', it's returned.
+        Otherwise (if None, empty string, etc.), '.*' is returned.
+        
+        Args:
+            params (dict): The dictionary to retrieve the value from.
+            key (str): The key whose value is to be retrieved.
+
+        Returns:
+            str: The 'truthy' value associated with the key, or '.*' if the value
+                 is 'falsy' or the key does not exist.
+        """
+        val = params.get(key)
+        return val if val else '.*'

--- a/api/libs/util_test.py
+++ b/api/libs/util_test.py
@@ -1,0 +1,56 @@
+import unittest
+
+from apo_utils import APOUtils
+
+class TestGetAndFillParam(unittest.TestCase):
+
+    def test_key_exists_and_value_is_non_empty_string(self):
+        """测试键存在且值为非空字符串的情况。"""
+        params = {"name": "Alice", "age": "30"}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "name"), "Alice")
+        self.assertEqual(APOUtils.get_and_fill_param(params, "age"), "30")
+
+    def test_key_exists_and_value_is_empty_string(self):
+        """测试键存在但值为**空字符串**的情况。预期返回 '.*'。"""
+        params = {"city": "", "zip": ""}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "city"), ".*")
+        self.assertEqual(APOUtils.get_and_fill_param(params, "zip"), ".*")
+
+    def test_key_exists_and_value_is_none(self):
+        """测试键存在但值为 **None** 的情况。预期返回 '.*'。"""
+        params = {"description": None, "status": None}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "description"), ".*")
+        self.assertEqual(APOUtils.get_and_fill_param(params, "status"), ".*")
+
+    def test_key_does_not_exist(self):
+        """测试键**不存在**于字典中的情况。params.get() 会返回 None，预期返回 '.*'。"""
+        params = {"id": "123"}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "address"), ".*")
+
+    def test_empty_params_dict(self):
+        """测试输入字典为空的情况。预期返回 '.*'。"""
+        params = {}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "some_key"), ".*")
+
+    def test_key_exists_and_value_is_zero(self):
+        """测试键存在但值为数字 0 的情况。预期返回 '.*'。"""
+        params = {"count": 0}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "count"), ".*")
+
+    def test_key_exists_and_value_is_false(self):
+        """测试键存在但值为布尔 False 的情况。预期返回 '.*'。"""
+        params = {"is_active": False}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "is_active"), ".*")
+
+    def test_key_exists_and_value_is_empty_list(self):
+        """测试键存在但值为空列表的情况。预期返回 '.*'。"""
+        params = {"items": []}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "items"), ".*")
+
+    def test_key_exists_and_value_is_empty_dict(self):
+        """测试键存在但值为空字典的情况。预期返回 '.*'。"""
+        params = {"data": {}}
+        self.assertEqual(APOUtils.get_and_fill_param(params, "data"), ".*")
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
## Summary by Sourcery

Centralize and streamline parameter acquisition in APOUtils by introducing get_and_fill_param and refactor existing tools to utilize it, simplifying default handling and updating query patterns, with accompanying tests for the new utility.

Enhancements:
- Add static get_and_fill_param method in APOUtils to standardize parameter defaulting and return '.*' for falsy or missing values
- Refactor numerous built-in APO select tool invocations to leverage get_and_fill_param instead of manual empty checks and conditional dict expansions
- Update Prometheus query fragments to use regex matching syntax for parameter filters

Tests:
- Introduce unit tests for get_and_fill_param covering various truthy and falsy scenarios