### PR TITLE
add push tag job

### DIFF
--- a/.github/workflows/release-image-api.yml
+++ b/.github/workflows/release-image-api.yml
@@ -67,3 +67,10 @@ jobs:
           tags: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-api:${{ inputs.tag }}-arm64
           cache-from: type=gha,scope=dify-api-arm64
           cache-to: type=gha,mode=max,scope=dify-api-arm64
+
+      - name: push tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release-image-api.yml
+++ b/.github/workflows/release-image-api.yml
@@ -1,0 +1,63 @@
+name: Build and Push Dify API Docker Image (Separate AMD64 & ARM64 tags)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to release'
+        required: true
+  push:
+    branches: [release-ci]
+  pull_request:
+    types: [closed]
+    branches: [release-ci]
+
+concurrency:
+  group: build-push-${{ github.run_id }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_HOST: registry.cn-hangzhou.aliyuncs.com
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  IMAGE_BASE: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-api
+
+jobs:
+  build-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Aliyun Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push AMD64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:api"
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}
+          cache-from: type=gha,scope=dify-api-amd64
+          cache-to: type=gha,mode=max,scope=dify-api-amd64
+
+      - name: Build & push ARM64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:api"
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}-arm64
+          cache-from: type=gha,scope=dify-api-arm64
+          cache-to: type=gha,mode=max,scope=dify-api-arm64

--- a/.github/workflows/release-image-api.yml
+++ b/.github/workflows/release-image-api.yml
@@ -20,7 +20,6 @@ env:
   REGISTRY_HOST: registry.cn-hangzhou.aliyuncs.com
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-  IMAGE_BASE: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-api
 
 jobs:
   build-api:
@@ -53,7 +52,7 @@ jobs:
           context: "{{defaultContext}}:api"
           platforms: linux/amd64
           push: true
-          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}
+          tags: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-api:${{ inputs.tag }}
           cache-from: type=gha,scope=dify-api-amd64
           cache-to: type=gha,mode=max,scope=dify-api-amd64
 
@@ -64,6 +63,6 @@ jobs:
           context: "{{defaultContext}}:api"
           platforms: linux/arm64
           push: true
-          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}-arm64
+          tags: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-api:${{ inputs.tag }}-arm64
           cache-from: type=gha,scope=dify-api-arm64
           cache-to: type=gha,mode=max,scope=dify-api-arm64

--- a/.github/workflows/release-image-api.yml
+++ b/.github/workflows/release-image-api.yml
@@ -27,9 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v2
 
       - name: Login to Aliyun Registry
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
@@ -37,12 +39,15 @@ jobs:
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/setup-buildx-action@v3
 
       - name: Build & push AMD64 image
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:api"
@@ -53,6 +58,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=dify-api-amd64
 
       - name: Build & push ARM64 image
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:api"

--- a/.github/workflows/release-image-web.yml
+++ b/.github/workflows/release-image-web.yml
@@ -66,3 +66,10 @@ jobs:
           tags: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-web:${{ inputs.tag }}-arm64
           cache-from: type=gha,scope=dify-web-arm64
           cache-to: type=gha,mode=max,scope=dify-web-arm64
+
+      - name: push tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release-image-web.yml
+++ b/.github/workflows/release-image-web.yml
@@ -53,7 +53,7 @@ jobs:
           context: "{{defaultContext}}:web"
           platforms: linux/amd64
           push: true
-          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}
+          tags: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-web:${{ inputs.tag }}
           cache-from: type=gha,scope=dify-web-amd64
           cache-to: type=gha,mode=max,scope=dify-web-amd64
 
@@ -64,6 +64,6 @@ jobs:
           context: "{{defaultContext}}:web"
           platforms: linux/arm64
           push: true
-          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}-arm64
+          tags: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-web:${{ inputs.tag }}-arm64
           cache-from: type=gha,scope=dify-web-arm64
           cache-to: type=gha,mode=max,scope=dify-web-arm64

--- a/.github/workflows/release-image-web.yml
+++ b/.github/workflows/release-image-web.yml
@@ -1,0 +1,63 @@
+name: Build and Push Dify Web Docker Image (Separate AMD64 & ARM64 tags)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to release'
+        required: true
+  push:
+    branches: [release-ci]
+  pull_request:
+    types: [closed]
+    branches: [release-ci]
+
+concurrency:
+  group: build-push-${{ github.run_id }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_HOST: registry.cn-hangzhou.aliyuncs.com
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  IMAGE_BASE: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-web
+
+jobs:
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Aliyun Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push AMD64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:web"
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}
+          cache-from: type=gha,scope=dify-web-amd64
+          cache-to: type=gha,mode=max,scope=dify-web-amd64
+
+      - name: Build & push ARM64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:web"
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_BASE }}:${{ inputs.tag }}-arm64
+          cache-from: type=gha,scope=dify-web-arm64
+          cache-to: type=gha,mode=max,scope=dify-web-arm64

--- a/.github/workflows/release-image-web.yml
+++ b/.github/workflows/release-image-web.yml
@@ -20,7 +20,6 @@ env:
   REGISTRY_HOST: registry.cn-hangzhou.aliyuncs.com
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-  IMAGE_BASE: ${{ env.REGISTRY_HOST }}/kindlingx/apo-dify-web
 
 jobs:
   build-web:

--- a/.github/workflows/release-image-web.yml
+++ b/.github/workflows/release-image-web.yml
@@ -27,9 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v2
 
       - name: Login to Aliyun Registry
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_HOST }}
@@ -37,12 +39,15 @@ jobs:
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/setup-buildx-action@v3
 
       - name: Build & push AMD64 image
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:web"
@@ -53,6 +58,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=dify-web-amd64
 
       - name: Build & push ARM64 image
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:web"


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

## Summary by Sourcery

Update release-image-api and release-image-web workflows to use explicit registry paths for Docker image tags and introduce a git tag push step on manual dispatch.

Enhancements:
- Replace IMAGE_BASE environment variable and references with direct REGISTRY_HOST paths for tagging api and web images
- Add a "push tag" step using anothrNick/github-tag-action@v1 triggered on manual workflow_dispatch events