### PR TITLE
Feat/introduce dataplane datasource

### DIFF
--- a/api/configs/apo/__init__.py
+++ b/api/configs/apo/__init__.py
@@ -111,3 +111,7 @@ class APOConfig(BaseSettings):
         description="apo detect series frequency threshold",
         default=3.0,
     )
+    DATA_SOURCE: str = Field (
+        description="metric source from ,options: [dataplane, apo]",
+        default="dataplane",
+    )

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_cfs.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_cfs.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class SelectContainerCPUTool(BuiltinTool):
     def _invoke(
@@ -25,22 +25,15 @@ class SelectContainerCPUTool(BuiltinTool):
           "pod": "pod",
           "namespace": "namespace"
         }
+
         metric_param = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-        params = {
-          'metricName': '基础设施情况 - 容器CPU - 容器CPU节流时间 - Containerd',
-          'params': metric_param,
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        query_result = query_metric(
+            metric_name='基础设施情况 - 容器CPU - 容器CPU节流时间 - Containerd',
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=metric_param,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_usage_containerd.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_cpu_usage_containerd.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -28,22 +27,14 @@ class ContainerCpuUsageContainerdTool(BuiltinTool):
             "pod": "pod"
         }
 
-        metric_param = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-        params = {
-            'metricName': '基础设施情况 - 容器CPU - 容器CPU使用率 - Containerd',
-            'params': metric_param,
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+        query_result = query_metric(
+            metric_name='基础设施情况 - 容器CPU - 容器CPU使用率 - Containerd',
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_time_containerd_seconds.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_disk_read_time_containerd_seconds.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -27,21 +26,15 @@ class ContainerDiskReadTimeContainerdSecondsTool(BuiltinTool):
             "namespace": "namespace",
             "pod": "pod"
         }
-        params = {
-            'metricName': '基础设施情况 - 容器磁盘 - 读写花费时间 /s - Read',
-            'params': APOUtils.get_and_build_metric_params(tool_parameters, key_map),
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+
+        query_result = query_metric(
+            metric_name='基础设施情况 - 容器磁盘 - 读写花费时间 /s - Read',
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_bandwidth_receive.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_network_bandwidth_receive.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -27,21 +26,15 @@ class ContainerNetworkBandwidthReceiveTool(BuiltinTool):
             "namespace": "namespace",
             "pod": "pod"
         }
-        params = {
-            'metricName': '基础设施情况 - 容器网络 - 网络带宽使用 - 接收',
-            'params': APOUtils.get_and_build_metric_params(tool_parameters, key_map),
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+        query_result = query_metric(
+            metric_name='基础设施情况 - 容器网络 - 网络带宽使用 - 接收',
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/container_rtt.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class ContainerRTTTool(BuiltinTool):
     def _invoke(
@@ -20,30 +20,15 @@ class ContainerRTTTool(BuiltinTool):
     ) -> Generator[ToolInvokeMessage, None, None]:
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-
-        key_map = {
-            "pod": "pod",
-            "namespace": "namespace",
-            "node": "node",
-            "pid": "pid",
-            "containerId": "container_id"
-        }
-        params = {
-          'metricName': '基础设施情况 - 容器网络 - 与下游服务RTT',
-          'params': APOUtils.get_and_build_metric_params(tool_parameters, key_map),
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
-
+        key_map = {"pod": "pod", "namespace": "namespace", "node": "node", "pid": "pid", "containerId": "container_id"}
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+        query_result = query_metric(
+            metric_name="基础设施情况 - 容器网络 - 与下游服务RTT",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_instance_service_name.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_instance_service_name.py
@@ -5,9 +5,9 @@ from typing import Any, Optional, Dict
 import requests
 
 from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import to_int
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from libs.apo_utils import APOUtils
 
 
 class InstanceServiceTool(BuiltinTool):
@@ -26,35 +26,16 @@ class InstanceServiceTool(BuiltinTool):
         start_time = tool_parameters.get('startTime')
         end_time = tool_parameters.get('endTime')
         cluster = tool_parameters.get('cluster', '')
+
         try:
-            request_body = {
-                "cluster": cluster,
-                "endTime": end_time,
-                "startTime": start_time,
-                "tags": {
-                    "containerId": container_id or '',
-                    "nodeName": node or '',
-                    "pid": pid or '',
-                    "pod": pod or ''
-                }
-            }
-
-            response = requests.post(
-                f"{dify_config.APO_BACKEND_URL}/api/dataplane/servicename",
-                json=request_body,
-                timeout=10,
-            )
-            response.raise_for_status()
-
-            result = response.json().get("result", {})
-
-            formatted_data = json.dumps(
-                {
-                    "type": "list",
-                    "display": True,
-                    "data": result,
-                },
-                indent=2,
+            formatted_data = query_service_name(
+                cluster=cluster,
+                pod=pod or '',
+                container_id=container_id or '',
+                pid=pid or '',
+                node=node or '',
+                start_time=start_time,
+                end_time=end_time,
             )
             yield self.create_text_message(formatted_data)
 
@@ -64,3 +45,53 @@ class InstanceServiceTool(BuiltinTool):
             yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
         except Exception as e:
             yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))
+
+
+def query_service_name(
+    cluster: str,
+    pod: str,
+    container_id: str,
+    pid: str,
+    node: str,
+    start_time: Any,
+    end_time: Any,
+) -> str:
+    start_ts = to_int(start_time)
+    end_ts = to_int(end_time)
+
+    request_body = {
+        "cluster": cluster,
+        "endTime": end_ts,
+        "startTime": start_ts,
+        "tags": {
+            "containerId": container_id,
+            "nodeName": node,
+            "pid": pid,
+            "pod": pod
+        }
+    }
+
+    url = ""
+    if dify_config.DATA_SOURCE == 'apo':
+        url = f"{dify_config.APO_BACKEND_URL}/api/dataplane/servicename"
+    else:
+        url = f"{dify_config.DATAPLANE_URL}/dataplane/servicename"
+
+    response = requests.post(
+        url,
+        json=request_body,
+        timeout=10,
+    )
+    response.raise_for_status()
+    result = response.json().get("result", {})
+
+    formatted_data = json.dumps(
+        {
+            "type": "list",
+            "display": True,
+            "data": result,
+        },
+        indent=2,
+    )
+    return formatted_data
+

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_instances.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_instances.py
@@ -1,13 +1,12 @@
 import json
 from collections.abc import Generator
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
 from configs import dify_config
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from libs.apo_utils import APOUtils
 
 
 class ServiceInstancesTool(BuiltinTool):
@@ -32,15 +31,20 @@ class ServiceInstancesTool(BuiltinTool):
         }
 
         try:
+            url = ""
+            if dify_config.DATA_SOURCE == 'apo':
+                url = f"{dify_config.APO_BACKEND_URL}/api/dataplane/instances"
+            else:
+                url = f"{dify_config.DATAPLANE_URL}/dataplane/instances"
+
             response = requests.get(
-                f"{dify_config.APO_BACKEND_URL}/api/dataplane/instances",
+                url,
                 params=query_params,
                 timeout=10,
             )
             response.raise_for_status()
 
-            result = response.json().get("results", {})
-
+            result = response.json().get("results", [])
             formatted_data = json.dumps(
                 {
                     "type": "list",
@@ -53,9 +57,18 @@ class ServiceInstancesTool(BuiltinTool):
             yield self.create_text_message(formatted_data)
 
         except requests.RequestException as e:
-            yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
+            yield self.create_text_message(json.dumps({"error": f"Error: Failed to fetch data from API. {str(e)}"}))
         except json.JSONDecodeError:
             yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
         except Exception as e:
             yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))
 
+
+def normalize_pid(instance: dict) -> None:
+    """如果存在 processpid,则将其转换为 int 并保存为 pid"""
+    if "processpid" in instance:
+        try:
+            instance["pid"] = int(instance["processpid"])
+        except (ValueError, TypeError):
+            # 转换失败则删除或置空，视需求而定
+            instance["pid"] = None

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_redcharts.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_redcharts.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
 from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import to_int
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from libs.apo_utils import APOUtils
 
 
 class ServiceEndpointsTool(BuiltinTool):
@@ -25,39 +25,63 @@ class ServiceEndpointsTool(BuiltinTool):
         start_time = tool_parameters.get('startTime')
         end_time = tool_parameters.get('endTime')
 
-        query_params = {
-            "service": service,
-            "cluster": cluster,
-            "startTime": start_time,
-            "endTime": end_time,
-            "endpoint": endpoint
-        }
-
         try:
-            response = requests.get(
-                f"{dify_config.APO_BACKEND_URL}/api/dataplane/redcharts",
-                params=query_params,
-                timeout=10,
+            formatted_data = query_service_redcharts(
+                service=service or '',
+                cluster=cluster or '',
+                endpoint=endpoint or '',
+                start_time=start_time,
+                end_time=end_time,
             )
-            response.raise_for_status()
-
-            result = response.json().get("results", {})
-
-            formatted_data = json.dumps(
-                {
-                    "type": "metric",
-                    "display": True,
-                    "data": result,
-                },
-                indent=2,
-            )
-
             yield self.create_text_message(formatted_data)
-
         except requests.RequestException as e:
             yield self.create_text_message(json.dumps({"error" : f"Error: Failed to fetch data from API. {str(e)}"}))
         except json.JSONDecodeError:
             yield self.create_text_message(json.dumps({"error": "Error: Invalid JSON response from API."}))
         except Exception as e:
             yield self.create_text_message(json.dumps({"error": f"Error: An unexpected error occurred. {str(e)}"}))
+
+
+def query_service_redcharts(
+    service: str,
+    cluster: str,
+    endpoint: str,
+    start_time: Any,
+    end_time: Any,
+) -> str:
+    start_ts = to_int(start_time)
+    end_ts = to_int(end_time)
+
+    request_params = {
+        "service": service,
+        "cluster": cluster,
+        "startTime": start_ts,
+        "endTime": end_ts,
+        "endpoint": endpoint
+    }
+
+    url = ""
+    if dify_config.DATA_SOURCE == 'apo':
+        url = f"{dify_config.APO_BACKEND_URL}/api/dataplane/redcharts"
+    else:
+        url = f"{dify_config.DATAPLANE_URL}/dataplane/redcharts"
+
+    response = requests.get(
+        url,
+        params=request_params,
+        timeout=10,
+    )
+    response.raise_for_status()
+
+    result = response.json().get("results", [])
+    formatted_data = json.dumps(
+        {
+            "type": "metric",
+            "display": True,
+            "data": result,
+        },
+        indent=2,
+    )
+    return formatted_data
+
 

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_topology.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/dataplane_service_topology.py
@@ -1,13 +1,12 @@
 import json
 from collections.abc import Generator
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
 from configs import dify_config
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from libs.apo_utils import APOUtils
 
 
 class ServiceTopologyTool(BuiltinTool):
@@ -32,8 +31,14 @@ class ServiceTopologyTool(BuiltinTool):
         }
 
         try:
+            url = ""
+            if dify_config.DATA_SOURCE == 'apo':
+                url = f"{dify_config.APO_BACKEND_URL}/api/dataplane/topology"
+            else:
+                url = f"{dify_config.DATAPLANE_URL}/dataplane/topology"
+
             response = requests.get(
-                f"{dify_config.APO_BACKEND_URL}/api/dataplane/topology",
+                url,
                 params=query_params,
                 timeout=10,
             )
@@ -50,7 +55,7 @@ class ServiceTopologyTool(BuiltinTool):
                 return {
                     "endpoint": node["id"],
                     "group": node["category"],
-                    "isTraced": True,  
+                    "isTraced": True,
                     "service": node["name"],
                     "system": node["category"]
                 }
@@ -70,7 +75,7 @@ class ServiceTopologyTool(BuiltinTool):
             ]
 
             formatted_data = json.dumps({
-                "type": "toopology",
+                "type": "topology",
                 "display": True,
                 "data": {
                     "children": formatted_children,

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_iowait.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_iowait.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class HostCPUIoWaitRespTool(BuiltinTool):
     def _invoke(
@@ -18,26 +18,17 @@ class HostCPUIoWaitRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = tool_parameters.get("node", ".*")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        params = {
-          'metricName': '宿主机监控指标 - Basic CPU / Mem / Net / Disk - CPU Basic - Busy Iowait',
-          'params': {
-            "node": node
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        labels = {"node": node}
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Basic CPU / Mem / Net / Disk - CPU Basic - Busy Iowait",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_pressure.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_cpu_pressure.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -21,26 +20,16 @@ class HostCpuPressureTool(BuiltinTool):
     ) -> Generator[ToolInvokeMessage, None, None]:
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        key_map = {
-            "node": "node",
-            "job": "job"
-        }
-        metric_params = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-        params = {
-          'metricName': "宿主机监控指标 - Quick CPU / Mem / Disk - Pressure - CPU",
-          'params': metric_params,
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        key_map = {"node": "node", "job": "job"}
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Quick CPU / Mem / Disk - Pressure - CPU",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_used.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_disk_used.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class HostDiskUsedTool(BuiltinTool):
     def _invoke(
@@ -18,26 +18,18 @@ class HostDiskUsedTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = tool_parameters.get("node", ".*")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        params = {
-          'metricName': '宿主机监控指标 - Basic CPU / Mem / Net / Disk - Disk Space Used Basic',
-          'params': {
-            "node": node
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Basic CPU / Mem / Net / Disk - Disk Space Used Basic",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels={"node": node},
+        )
+
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_fd_open.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_fd_open.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class HostCPUIoWaitRespTool(BuiltinTool):
     def _invoke(
@@ -18,33 +18,22 @@ class HostCPUIoWaitRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = tool_parameters.get("node", ".*")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        job = tool_parameters.get('job')
-        if not job:
-            job = '.*'
-        params = {
-          'metricName': '宿主机监控指标 - Storage Filesystem - File Descriptor - Open files',
-          'params': {
+        job = tool_parameters.get("job")
+        labels = {
             "node": node,
             "job": job,
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(
-            f'{dify_config.APO_BACKEND_URL}/api/metric/query', json=params
+        }
+
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Storage Filesystem - File Descriptor - Open files",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
         )
-        resp_data = resp.json()
-        list = resp_data["result"]
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_net_recv.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_net_recv.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class HostCPUIoWaitRespTool(BuiltinTool):
     def _invoke(
@@ -18,26 +18,18 @@ class HostCPUIoWaitRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
+        node = tool_parameters.get("node", ".*")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        params = {
-          'metricName': '宿主机监控指标 - Basic CPU / Mem / Net / Disk - Network Traffic Basic - recv',
-          'params': {
-            "node": node
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+
+        labels = {"node": node}
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Basic CPU / Mem / Net / Disk - Network Traffic Basic - recv",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_ram_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_ram_usage.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -19,28 +18,17 @@ class HostRamUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        key_map = {
-            "node": "node",
-            "job": "job"
-        }
+        key_map = {"node": "node", "job": "job"}
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        metric_params = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-        params = {
-          'metricName': "宿主机监控指标 - Quick CPU / Mem / Disk - RAM Used - B",
-          'params': metric_params,
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Quick CPU / Mem / Disk - RAM Used - B",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/host_swap_usage.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/host_swap_usage.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -19,28 +18,19 @@ class HostSwapUsageTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        node = tool_parameters.get("node", '.*')
-        job = tool_parameters.get("job", '.*')
+        node = tool_parameters.get("node", ".*")
+        job = tool_parameters.get("job", ".*")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        params = {
-          'metricName': "宿主机监控指标 - Quick CPU / Mem / Disk - SWAP Used",
-          'params': {
-            'node': node,
-            'job': job
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+
+        labels = {"node": node, "job": job}
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - Quick CPU / Mem / Disk - SWAP Used",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_io_utilization.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/node_disk_io_utilization.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -19,30 +18,21 @@ class NodeDiskIoUtilizationTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        job = tool_parameters.get('job', '.*')
-        node = tool_parameters.get('node', '.*')
+        job = tool_parameters.get("job", ".*")
+        node = tool_parameters.get("node", ".*")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         if not job:
-            job = '.*'
-        params = {
-            'metricName': '宿主机监控指标 - CPU / Memory / Net / Disk - I/O Utilization',
-            'params': {
-                'job': job,
-                'node': node
-            },
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+            job = ".*"
+
+        labels = {"job": job, "node": node}
+        query_result = query_metric(
+            metric_name="宿主机监控指标 - CPU / Memory / Net / Disk - I/O Utilization",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_monitor.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_monitor.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class OriginxServiceMonitorTool(BuiltinTool):
     def _invoke(
@@ -22,24 +22,15 @@ class OriginxServiceMonitorTool(BuiltinTool):
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
         pid = tool_parameters.get("pid")
-        params = {
-          'metricName': 'Thread Polaris Metrics - 北极星指标（进程） - 节点上被监控的服务列表',
-          'params': {
-            "node_name": node_name,
-            **({'pid': pid} if pid else {})
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+
+        labels = {"node_name": node_name, **({"pid": pid} if pid else {})}
+        query_result = query_metric(
+            metric_name="Thread Polaris Metrics - 北极星指标（进程） - 节点上被监控的服务列表",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_red_resp_ok.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/originx_service_red_resp_ok.py
@@ -1,13 +1,14 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
 from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import QueryMetricResult, query_metric, query_red_metrics
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class OriginxServiceRedRespOkTool(BuiltinTool):
     def _invoke(
@@ -18,28 +19,49 @@ class OriginxServiceRedRespOkTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
+        service_name = tool_parameters.get("service_name")
+        content_key = tool_parameters.get("content_key")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        key_map = {
-          "service_name": "service_name",
-          "content_key": "content_key"
-        }
-        metric_params = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-        params = {
-          'metricName': 'Originx 北极星指标 (服务层级) - RED指标 - 请求成功率',
-          'params': metric_params,
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+
+        metric_name = "Originx 北极星指标 (服务层级) - RED指标 - 请求成功率"
+
+        try:
+            if dify_config.DATA_SOURCE == "apo":
+                labels = {
+                    "service_name": service_name or "",
+                    "content_key": content_key or ""
+                }
+                query_result = query_metric(
+                    metric_name=metric_name,
+                    start_time=start_time,
+                    end_time=end_time,
+                    step=APOUtils.get_step(start_time, end_time),
+                    labels=labels,
+                )
+                resp = asdict(query_result)
+                resp_str = json.dumps(resp)
+            else:
+                query_result = query_red_metrics(
+                   title="Success Rate",
+                   service=service_name or "",
+                   cluster="",
+                   start_time=start_time,
+                   end_time=end_time,
+                   endpoint=content_key or "",
+                )
+                resp = asdict(query_result)
+                resp_str = json.dumps(resp)
+        except Exception as e:
+            # 捕获异常，返回空 QueryResult 或自定义错误处理
+            print(f"Error querying metric {metric_name} by {dify_config.DATA_SOURCE}: {e}")
+            resp_str = json.dumps(QueryMetricResult(
+                type="metric",
+                display=True,
+                unit="",
+                data={"timeseries": []},
+            ))
+
+        yield self.create_text_message(resp_str)
+
+

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/polar_process_all_resp.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/polar_process_all_resp.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 class PolarProcessAllRespTool(BuiltinTool):
     def _invoke(
@@ -18,26 +18,18 @@ class PolarProcessAllRespTool(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        pod = tool_parameters.get("pod")
+        pod = tool_parameters.get("pod", "")
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
-        params = {
-          'metricName': 'Thread Polaris Metrics - 北极星指标（进程） - 各类型耗时折线图 - 所有类型列表',
-          'params': {
-            "pod": pod
-          },
-          'startTime': start_time,
-          'endTime': end_time,
-          'step': APOUtils.get_step(start_time, end_time),
-          }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                "timeseries": list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        labels = {"pod": pod}
+
+        query_result = query_metric(
+            metric_name="Thread Polaris Metrics - 北极星指标（进程） - 各类型耗时折线图 - 所有类型列表",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/service_last_seen.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/service_last_seen.py
@@ -5,9 +5,11 @@ from typing import Any, Optional
 import requests
 
 from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
+
 
 # TODO need more test
 class ServiceLastSeen(BuiltinTool):
@@ -19,8 +21,8 @@ class ServiceLastSeen(BuiltinTool):
         app_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        start_time = tool_parameters.get("startTime")
-        end_time = tool_parameters.get("endTime")
+        start_time = tool_parameters.get("startTime", 0)
+        end_time = tool_parameters.get("endTime", 0)
         workload_name = tool_parameters.get("workloadName")
         comm = tool_parameters.get("comm")
         node_name = tool_parameters.get("nodeName")
@@ -38,20 +40,73 @@ class ServiceLastSeen(BuiltinTool):
             by_labels.append("comm")
         if pid:
             label_filters.append(f'pid="{pid}"')
-        label_str = "{" + ",".join(label_filters) + "}"
-        by_str = ",".join(by_labels)
-
-        interval = APOUtils.get_step_with_unit(start_time, end_time)
-        query = f"max(originx_process_last_seen{label_str}) by({by_str})"
-        params = {
-            "query": query,
-            "time": end_time / 1000,
-        }
 
         try:
-            resp = requests.get(dify_config.APO_VM_URL + "/prometheus/api/v1/query", params=params, timeout=10)
-            resp.raise_for_status()
-            data = resp.json()
+            if dify_config.DATA_SOURCE == "apo":
+                label_str = "{" + ",".join(label_filters) + "}"
+                by_str = ",".join(by_labels)
+                interval = APOUtils.get_step_with_unit(start_time, end_time)
+                query = f"max(originx_process_last_seen{label_str}) by({by_str})"
+                params = {
+                    "query": query,
+                    "time": end_time / 1000,
+                }
+
+                resp = requests.get(dify_config.APO_VM_URL + "/prometheus/api/v1/query", params=params, timeout=10)
+                resp.raise_for_status()
+                data = resp.json()
+
+                last_seen = ""
+                for res in data.get("data", {}).get("result", []):
+                    value_pair = res.get("value", [])
+                    if len(value_pair) == 2:
+                        try:
+                            last_seen = value_pair[1]
+                        except Exception:
+                            pass
+
+                resp_json = json.dumps({
+                    "type": "metric",
+                    "display": False,
+                    "unit": "s",
+                    "data": last_seen
+                })
+
+                yield self.create_text_message(resp_json)
+            else:
+                params = {
+                    "node_name": node_name or ".*",
+                    "workload_name": workload_name or ".*",
+                    "comm": comm or ".*",
+                    "pid": pid or ".*"
+                }
+
+                query_result = query_metric(
+                    metric_name="Originx 北极星指标 (服务层级) - service.process_last_seen",
+                    start_time=end_time,  # Set startTime = endTime to query a single point
+                    end_time=end_time,
+                    step=APOUtils.get_step(start_time, end_time),
+                    labels=params,
+                )
+
+                last_seen = 0
+                for ts in query_result.data.get("timeseries", []):
+                    chart_data = ts.get("chart", {}).get("chartData", {})
+                    if isinstance(chart_data, dict):
+                        max_val = max(chart_data.values(), default=0)
+                        last_seen = max(last_seen, max_val)
+
+                if last_seen == 0:
+                    last_seen = ""
+
+                resp_json = json.dumps({
+                    "type": "metric",
+                    "display": False,
+                    "unit": "s",
+                    "data": last_seen
+                })
+
+                yield self.create_text_message(resp_json)
         except Exception as e:
             yield self.create_text_message(json.dumps({
                 "type": "error",
@@ -60,20 +115,5 @@ class ServiceLastSeen(BuiltinTool):
             }))
             return
 
-        last_seen = ""
-        for res in data.get("data", {}).get("result", []):
-            value_pair = res.get("value", [])
-            if len(value_pair) == 2:
-                try:
-                    last_seen = value_pair[1]
-                except Exception:
-                    pass
-            
 
-        resp_json = json.dumps({
-            "type": "metric",
-            "display": False,
-            "unit": "s",
-            "data": last_seen
-        })
-        yield self.create_text_message(resp_json)
+

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/service_process_count.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/service_process_count.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 import requests
 
 from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -25,35 +26,45 @@ class ServiceProcessCount(BuiltinTool):
         is_history = tool_parameters.get("isHistory")
         node_name = tool_parameters.get("nodeName")
 
-        label_filters = []
-        if node_name:
-            label_filters = [f'node_name="{node_name}"']
-        if workload_name:
-            label_filters.append(f'workload_name="{workload_name}"')
-        if comm:
-            label_filters.append(f'comm="{comm}"')
-
-        label_str = ""
-        if label_filters:
-            label_str = "{" + ",".join(label_filters) + "}"
-
-        query = ""
-        if not is_history:
-            query = f"count(originx_process_last_seen{label_str})"
-        else:
-            query = (
-                f"avg_over_time("
-                f"count(originx_process_last_seen{label_str})[10m:])"
-            )
-        params = {
-            "query": query,
-            "time": end_time / 1000,
-        }
-
         try:
-            resp = requests.get(dify_config.APO_VM_URL + "/prometheus/api/v1/query", params=params, timeout=10)
-            resp.raise_for_status()
-            data = resp.json()
+            if dify_config.DATA_SOURCE == "apo":
+                resp_json = __query_by_apo(end_time, node_name, workload_name, comm, is_history)
+            else:
+                params = {
+                    "node_name": node_name or ".*",
+                    "workload_name": workload_name or ".*",
+                    "comm": comm or ".*",
+                }
+
+                if is_history:
+                    metric_name = "service.process_count_avg_last_10m"
+                else:
+                    metric_name = "service.process_count"
+
+                query_result = query_metric(
+                    metric_name=metric_name,
+                    start_time=end_time,  # Set startTime = endTime to query a single point
+                    end_time=end_time,
+                    step=APOUtils.get_step(end_time, end_time),
+                    labels=params,
+                )
+
+                avg_count = 0
+                for ts in query_result.data.get("timeseries", []):
+                    chart_data = ts.get("chart", {}).get("chartData", {})
+                    if isinstance(chart_data, dict):
+                        max_val = max(chart_data.values(), default=0)
+                        avg_count = max(avg_count, max_val)
+
+                if avg_count == 0:
+                    avg_count = ""
+
+                resp_json = json.dumps({
+                    "type": "metric",
+                    "display": False,
+                    "unit": "count",
+                    "data": avg_count
+                })
         except Exception as e:
             yield self.create_text_message(json.dumps({
                 "type": "error",
@@ -62,20 +73,60 @@ class ServiceProcessCount(BuiltinTool):
             }))
             return
 
-        count = 0
-        for res in data.get("data", {}).get("result", []):
-            value_pair = res.get("value", [])
-            if len(value_pair) == 2:
-                try:
-                    count = float(value_pair[1])
-                except Exception:
-                    pass
-            
-
-        resp_json = json.dumps({
-            "type": "metric",
-            "display": False,
-            "unit": "count",
-            "data": count
-        })
         yield self.create_text_message(resp_json)
+
+
+def __query_by_apo(
+    end_time: Optional[int],
+    node_name: Optional[str],
+    workload_name: Optional[str],
+    comm: Optional[str],
+    is_history: Optional[bool],
+) -> str:
+    label_filters = []
+    if node_name:
+        label_filters = [f'node_name="{node_name}"']
+    if workload_name:
+        label_filters.append(f'workload_name="{workload_name}"')
+    if comm:
+        label_filters.append(f'comm="{comm}"')
+
+    label_str = ""
+    if label_filters:
+        label_str = "{" + ",".join(label_filters) + "}"
+
+    query = ""
+    if not is_history:
+        query = f"count(originx_process_last_seen{label_str})"
+    else:
+        query = (
+            f"avg_over_time("
+            f"count(originx_process_last_seen{label_str})[10m:])"
+        )
+
+    end_time = end_time or 0
+    params = {
+        "query": query,
+        "time": end_time / 1000,
+    }
+
+    resp = requests.get(dify_config.APO_VM_URL + "/prometheus/api/v1/query", params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+
+    count = 0
+    for res in data.get("data", {}).get("result", []):
+        value_pair = res.get("value", [])
+        if len(value_pair) == 2:
+            try:
+                count = float(value_pair[1])
+            except Exception:
+                pass
+
+    resp_json = json.dumps({
+        "type": "metric",
+        "display": False,
+        "unit": "count",
+        "data": count
+    })
+    return resp_json

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_epoll_time.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -22,29 +21,15 @@ class ThreadPolarisEpollTimeTool(BuiltinTool):
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
-        key_map = {
-            "pod": "pod",
-            "nodeName": "node_name",
-            "pid": "pid",
-            "containerId": "container_id"
-        }
-        metric_params = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-
-        params = {
-            'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Epoll',
-            'params': metric_params,
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        key_map = {"pod": "pod", "nodeName": "node_name", "pid": "pid", "containerId": "container_id"}
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+        query_result = query_metric(
+            metric_name="Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Epoll",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_net_time.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -22,28 +21,16 @@ class ThreadPolarisNetTimeTool(BuiltinTool):
         start_time = tool_parameters.get("startTime")
         end_time = tool_parameters.get("endTime")
 
-        key_map = {
-            "pod": "pod",
-            "nodeName": "node_name",
-            "pid": "pid",
-            "containerId": "container_id"
-        }
-        metric_params = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-        params = {
-            'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Net',
-            'params': metric_params,
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        key_map = {"pod": "pod", "nodeName": "node_name", "pid": "pid", "containerId": "container_id"}
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+
+        query_result = query_metric(
+            metric_name="Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - Net",
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.py
+++ b/api/core/tools/builtin_tool/providers/apo_select/tools/thread_polaris_oncpu_time.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Generator
+from dataclasses import asdict
 from typing import Any, Optional
 
-import requests
-
-from configs import dify_config
+from core.tools.builtin_tool.providers.data_source import query_metric
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from libs.apo_utils import APOUtils
@@ -28,23 +27,14 @@ class ThreadPolarisOncpuTimeTool(BuiltinTool):
             "pid": "pid",
             "containerId": "container_id"
         }
-        metric_params = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
-
-        params = {
-            'metricName': 'Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - OnCPU',
-            'params': metric_params,
-            'startTime': start_time,
-            'endTime': end_time,
-            'step': APOUtils.get_step(start_time, end_time),
-        }
-        resp = requests.post(dify_config.APO_BACKEND_URL + '/api/metric/query', json=params)
-        list = resp.json()['result']
-        list = json.dumps({
-            'type': 'metric',
-            'display': True,
-            'unit': list['unit'],
-            'data': {
-                'timeseries': list['timeseries']
-            }
-        })
-        yield self.create_text_message(list)
+        labels = APOUtils.get_and_build_metric_params(tool_parameters, key_map)
+        query_result = query_metric(
+            metric_name='Thread Polaris Metrics - 北极星指标（线程） - 各类型耗时折线图 - OnCPU',
+            start_time=start_time,
+            end_time=end_time,
+            step=APOUtils.get_step(start_time, end_time),
+            labels=labels,
+        )
+        resp = asdict(query_result)
+        resp_str = json.dumps(resp)
+        yield self.create_text_message(resp_str)

--- a/api/core/tools/builtin_tool/providers/data_source.py
+++ b/api/core/tools/builtin_tool/providers/data_source.py
@@ -1,0 +1,390 @@
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import requests
+from pydantic import ValidationError
+
+from configs import dify_config
+
+ProviderPriority = ["apo", "prometheusmetric"]  # 优先分析 apo / prometheus 的返回结果
+ProviderPriorityIndex = {v: i for i, v in enumerate(ProviderPriority)}  # 优化索引查找
+
+
+@dataclass
+class QueryMetricResult:
+    type: str = "metric"
+    display: bool = True
+    unit: str = ""
+    data: dict[str, list] = field(default_factory=dict)
+
+
+def query_metric(
+    metric_name: str,
+    start_time: Any,
+    end_time: Any,
+    step: int,
+    labels: Optional[dict[str, str]] = None,
+    compare: Optional[list[str]] = None,
+) -> QueryMetricResult:
+    """
+    根据配置查询指标，统一返回 QueryResult 对象。
+
+    Args:
+        metric_name: 指标名
+        start_time: 查询起始时间（时间戳）
+        end_time: 查询结束时间（时间戳）
+        step: 查询步长（秒）
+        labels: 可选标签过滤
+        compare: 可选对比维度（仅 dataplane 生效）
+
+    Returns:
+        QueryResult 对象
+    """
+
+    labels = labels or {}
+    compare = compare or []
+
+    try:
+        start_ts = to_int(start_time)
+        end_ts = to_int(end_time)
+
+        if dify_config.DATA_SOURCE == "dataplane":
+            # 调用 dataplane 查询
+            return __query_metric_by_dataplane(
+                metric_name=metric_name,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                step=step,
+                labels=labels,
+                compare=compare,
+            )
+
+        # 调用 APO 查询
+        return __query_metric_by_apo(
+            metric_name=metric_name,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            step=step,
+            labels=labels,
+        )
+
+    except Exception as e:
+        # 捕获异常，返回空 QueryResult 或自定义错误处理
+        print(f"Error querying metric {metric_name} by {dify_config.DATA_SOURCE}: {e}")
+        return QueryMetricResult(
+            type="metric",
+            display=True,
+            unit="",
+            data={"timeseries": []},
+        )
+
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class QueryMetricsRequest(BaseModel):
+    providerId: int = Field(..., description="接入数据源ID")
+    startTime: int = Field(..., description="开始时间")
+    endTime: int = Field(..., description="结束时间")
+    metric: str = Field(..., description="指标名，如 http_requests_total")
+    labels: Optional[dict[str, str]] = Field(default=None, description='维度标签，如 {"service": "svc-a"}')
+    step: Optional[int] = Field(default=None, description="步长")
+    compare: Optional[list[str]] = Field(
+        default=None, description='可选值：["dayOverDay", "weekOverDay"]，是否统计日同比和周同比'
+    )
+
+
+class ChartData(BaseModel):
+    chartData: dict[str, float]  # 时间戳（字符串）到指标值的映射？确认有序性
+    # value: Optional[Any] = None              # 平均值
+    # ratio: dict[str, Optional[Any]] = {}     # {"dayOverDay": None, "weekOverDay": None}
+
+    def avg_value(self) -> float:
+        """
+        计算图表数据的平均值
+        """
+        vals = [v for v in self.chartData.values() if v is not None]
+        if not vals:
+            return 0.0
+        return sum(vals) / len(vals)
+
+    def avg_spike(self) -> float:
+        """将原表数据按时间分成上下两部分,分别计算平均值, 返回平均值的突变比例"""
+        sorted_items = list(self.chartData.items())  # 或者 sorted(self.chartData.items(), key=lambda x: x[0])
+        mid = len(sorted_items) // 2
+
+        # 前半段平均值
+        first_vals = [v for _, v in sorted_items[:mid] if v is not None]
+        avg_first = sum(first_vals) / len(first_vals) if first_vals else 0.0
+
+        # 后半段平均值
+        second_vals = [v for _, v in sorted_items[mid:] if v is not None]
+        avg_second = sum(second_vals) / len(second_vals) if second_vals else 0.0
+
+        # 避免除零
+        if avg_first == 0.0:
+            return float("inf") if avg_second != 0 else 0.0
+
+        return (avg_second - avg_first) / avg_first
+
+
+class TimeSeries(BaseModel):
+    legend: str  # 图例（pod:container 格式）
+    legendFormat: str  # 图例格式（固定 "{{pod}}: {{ container }}"）
+    labels: dict[str, str]  # 标签（pod、container 等）
+    chart: ChartData  # 图表数据
+
+
+class MetricResult(BaseModel):
+    title: str  # 指标名称
+    unit: str  # 单位（如 "core"）
+    timeseries: list[TimeSeries] = Field(default_factory=list)  # 时间序列数组
+
+
+class MetricResults(BaseModel):
+    metrics: list[MetricResult] = Field(default_factory=list)
+
+
+class MetricResponse(BaseModel):
+    msg: str  # 空字符串，保持格式一致
+    result: MetricResult  # 核心数据部分
+    # success 字段根据需要可加
+
+
+class QueryMetricsResult(BaseModel):
+    providerId: int  # 接入数据源 ID
+    clusterId: str  # 集群 ID
+    dataSource: str  # 数据源名称
+    metrics: Optional[MetricResponse] = None  # 核心指标结果
+    error: Optional[str] = None  # 错误信息，可为空
+
+
+class QueryMetricsResponse(BaseModel):
+    data: list[QueryMetricsResult]
+
+
+def __query_metric_by_dataplane(
+    metric_name: str,
+    start_ts: int,
+    end_ts: int,
+    step: int,
+    labels: dict[str, str],
+    compare: list[str],
+) -> QueryMetricResult:
+    """
+    Query metric by dataplane
+
+    Args:
+        metric_name (str): metric name
+        start_ts (int): start timestamp in microseconds
+        end_ts (int): end timestamp in microseconds
+        step (int): step
+        labels (Optional[dict[str, str]]): labels
+        compare (Optional[list[str]]): compare,options: ["dayOverDay", "weekOverDay"]
+
+    Returns:
+        Optional[query_result]: query result
+    """
+    try:
+        url = f"{dify_config.DATAPLANE_URL}/datasource/queryMetrics"
+        req = QueryMetricsRequest(
+            providerId=0,
+            metric=metric_name,
+            labels=labels,
+            startTime=start_ts,
+            endTime=end_ts,
+            step=step,
+            compare=compare,
+        )
+
+        resp = requests.post(url, json=req.model_dump())
+        resp.raise_for_status()
+
+        data = resp.json()
+        if error := data.get("error"):
+            print(f"Error querying metric: {error}")
+            return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+        mr = QueryMetricsResponse.model_validate(data)
+        return __convert_metric_results(mr)
+    except requests.RequestException as e:
+        print(f"HTTP request failed: {e}")
+    except ValidationError as e:
+        print(f"Response validation failed: {e}")
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+
+    return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+
+
+def __convert_metric_results(
+    metric_response: QueryMetricsResponse,
+) -> QueryMetricResult:
+    if not metric_response.data:
+        return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+
+    # TODO merge different metric results' timeseries, need to ensure unit consistency
+    metricResult = __select_highest_priority_result(metric_response)
+    if metricResult is None:
+        return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+
+    if metricResult.error or not metricResult.metrics or not metricResult.metrics.result.timeseries:
+        return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+
+    mr = metricResult.metrics.result
+    return QueryMetricResult(
+        type="metric",
+        display=True,
+        unit=mr.unit,
+        data={"timeseries": [m.model_dump() for m in mr.timeseries]},
+    )
+
+
+def __select_highest_priority_result(results: QueryMetricsResponse) -> Optional[QueryMetricsResult]:
+    """从多个数据源中选择优先级最高的数据源结果"""
+    if not results or not results.data:
+        return None
+
+    best_result = None
+    for res in results.data:
+        if not res.metrics or not res.metrics.result.timeseries:
+            continue
+
+        if not best_result:
+            best_result = res
+            continue
+        else:
+            best_priority = ProviderPriorityIndex.get(best_result.dataSource, float("inf"))
+            current_priority = ProviderPriorityIndex.get(res.dataSource, float("inf"))
+            if current_priority < best_priority:
+                best_result = res
+    return best_result
+
+
+def __query_metric_by_apo(
+    metric_name: str,
+    start_ts: int,
+    end_ts: int,
+    step: int,
+    labels: dict[str, str],
+) -> QueryMetricResult:
+    reqBody = {
+        "metricName": metric_name,
+        "params": labels or {},
+        "startTime": start_ts,
+        "endTime": end_ts,
+        "step": step,
+    }
+
+    resp = requests.post(dify_config.APO_BACKEND_URL + "/api/metric/query", json=reqBody)
+    list = resp.json()["result"]
+    return QueryMetricResult(
+        type="metric",
+        display=True,
+        unit=list["unit"],
+        data={"timeseries": list["timeseries"]},
+    )
+
+
+def to_int(value: Any, default: Optional[int] = None) -> int:
+    if isinstance(value, int):
+        return value
+    if value is None:
+        if default is not None:
+            return default
+        raise ValueError("Cannot convert None to int")
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                if default is not None:
+                    return default
+                raise ValueError("Empty string cannot be converted to int")
+            if "." in value:
+                return int(float(value))
+        return int(value)
+    except (ValueError, TypeError):
+        if default is not None:
+            return default
+        raise
+
+
+class QueryServiceRedChartsResponse(BaseModel):
+    msg: str
+    results: list[MetricResult] = Field(default_factory=list)
+
+
+def query_red_metrics(
+    title: str,
+    service: str,
+    cluster: str,
+    start_time: Any,
+    end_time: Any,
+    endpoint: str,
+) -> QueryMetricResult:
+    """
+
+    Args:
+        title (str): Options: ["Response Time","Error Rate","Tpm","Success Rate"]
+        service (str): service_name
+        cluster (str): cluster
+        start_time (Any): start_ts in microseconds
+        end_time (Any): end_ts in microseconds
+        endpoint (str): content_key
+
+    Returns:
+        QueryMetricResult: metric result
+    """
+    start_ts = to_int(start_time)
+    end_ts = to_int(end_time)
+
+    request_params = {"service": service, "cluster": "", "startTime": start_ts, "endTime": end_ts, "endpoint": endpoint}
+
+    resp = requests.get(
+        f"{dify_config.DATAPLANE_URL}/dataplane/redcharts",
+        params=request_params,
+        timeout=10,
+    )
+    resp.raise_for_status()
+
+    data = resp.json()
+    if error := data.get("error"):
+        print(f"Error querying metric: {error}")
+        return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+    mr = QueryServiceRedChartsResponse.model_validate(data)
+    return __convert_red_results(title, mr)
+
+
+def __convert_red_results(
+    title: str,
+    metric_response: QueryServiceRedChartsResponse,
+) -> QueryMetricResult:
+    if not metric_response.results:
+        return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+
+    for metric in metric_response.results:
+        if metric.title == title:
+            return QueryMetricResult(
+                type="metric",
+                display=True,
+                unit=metric.unit,
+                data={"timeseries": [m.model_dump() for m in metric.timeseries]},
+            )
+        elif metric.title == "Error Rate" and title == "Success Rate":
+            return __error_rate_to_success_rate(metric)
+
+    return QueryMetricResult(type="metric", display=True, unit="", data={"timeseries": []})
+
+
+def __error_rate_to_success_rate(error_rate: MetricResult) -> QueryMetricResult:
+    for ts in error_rate.timeseries:
+        for key, value in ts.chart.chartData.items():
+            ts.chart.chartData[key] = round((100 - value) / 100, 2)
+
+    return QueryMetricResult(
+        type="metric",
+        display=True,
+        unit="percentunit",
+        data={"timeseries": [m.model_dump() for m in error_rate.timeseries]},
+    )

--- a/api/libs/apo_utils.py
+++ b/api/libs/apo_utils.py
@@ -1,7 +1,6 @@
 class APOUtils:
-
-    @classmethod
-    def get_step(self, start_time, end_time):
+    @staticmethod
+    def get_step(start_time, end_time):
         time_diff = end_time - start_time
 
         SECOND = 1000000  # microseconds
@@ -73,6 +72,7 @@ class APOUtils:
 
         return step
 
+    @staticmethod
     def get_and_build_metric_params(param: dict, key_map: dict) -> dict:
         """
         从param字典中提取指定的key，并根据key_map映射构建新的参数字典
@@ -114,4 +114,4 @@ def get_history_timeseries(legend: str, labels: dict, history: dict) -> dict:
         current_labels = entry["labels"]
         if labels == current_labels:
             return chart_data
-    return None
+    return {}


### PR DESCRIPTION
Introduce a new optional data source ‘dataplane’ and unify the interfaces used for data queries.

## Summary by Sourcery

Introduce a new optional dataplane data source and centralize metric querying across built-in tools by abstracting API calls into a unified data_source module.

New Features:
- Add DATA_SOURCE configuration to toggle between APO and dataplane backends
- Implement data_source module exposing query_metric, query_red_metrics, to_int, and dataplane/apo fallback logic
- Provide new query_service_name and query_service_redcharts helpers for dataplane-specific endpoints

Enhancements:
- Refactor all existing tool implementations to replace direct HTTP requests with the unified data_source API
- Migrate metric parameter building and step calculation into static utilities in APOUtils
- Support dual-source querying in legacy tools with __query_by_apo fallback paths